### PR TITLE
Fix hidden box persistence

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -104,9 +104,11 @@ export default function Home() {
         window.addEventListener('keydown', onKeyDown)
 
         function onKeyDown(event: KeyboardEvent) {
+            const currentState = useStore.getState()
+
             if (event.key === 'Escape') {
                 selectedGroups = []
-                state.setSelectedGroups(selectedGroups)
+                currentState.setSelectedGroups(selectedGroups)
             }
             if (event.key === 'c') {
                 onCombineClick()
@@ -119,106 +121,94 @@ export default function Home() {
             }
         }
 
+        function rebuildBoxFromCurrentState() {
+            const currentState = useStore.getState()
+            const scene = currentState.sceneRef.current
+            const currentBox = currentState.boxRef.current
+            if (!scene || !currentBox) return
+
+            scene.remove(currentBox)
+            const newBox = generateCustomBox(
+                currentState.gridRef.current,
+                currentState.wallThickness,
+                currentState.cornerRadius,
+                currentState.generateBottom
+            )
+            currentState.boxRef.current = newBox
+            newBox.position.set(
+                -currentState.totalWidth / 2,
+                0,
+                -currentState.totalDepth / 2
+            )
+            scene.add(newBox)
+        }
+
         function onCombineClick() {
-            if (selectedGroups.length < 2) return
+            const currentState = useStore.getState()
+            const groupsToCombine = currentState.selectedGroups
+            if (groupsToCombine.length < 2) return
+            const currentBox = currentState.boxRef.current
+            if (!currentBox) return
 
             const existing = new Set<number>(
-                (state.boxRef.current!.children as THREE.Group[]).map(
+                (currentBox.children as THREE.Group[]).map(
                     (g) => g.userData.group as number
                 )
             )
             let newId = 1
             while (existing.has(newId)) newId++
 
-            const grid = state.gridRef.current!
-            selectedGroups.forEach((grp) => {
+            const grid = currentState.gridRef.current
+            groupsToCombine.forEach((grp) => {
                 const cells: { x: number; z: number }[] = grp.userData.cells
                 cells.forEach(({ x, z }) => {
                     grid[z][x].group = newId
                 })
             })
 
-            const scene = state.sceneRef.current!
-            scene.remove(state.boxRef.current!)
-            const newBox = generateCustomBox(
-                grid,
-                state.wallThickness,
-                state.cornerRadius,
-                state.generateBottom
-            )
-            state.boxRef.current = newBox
-            newBox.position.set(
-                -useStore.getState().totalWidth / 2,
-                0,
-                -useStore.getState().totalDepth / 2
-            )
-            scene.add(newBox)
+            rebuildBoxFromCurrentState()
 
             selectedGroups = []
-            state.setSelectedGroups(selectedGroups)
+            currentState.setSelectedGroups(selectedGroups)
         }
 
         function onSplitClick() {
-            if (selectedGroups.length === 0) return
+            const currentState = useStore.getState()
+            const groupsToSplit = currentState.selectedGroups
+            if (groupsToSplit.length === 0) return
 
-            const grid = state.gridRef.current!
-            selectedGroups.forEach((grp) => {
+            const grid = currentState.gridRef.current
+            groupsToSplit.forEach((grp) => {
                 const cells: { x: number; z: number }[] = grp.userData.cells
                 cells.forEach(({ x, z }) => {
                     grid[z][x].group = 0
                 })
             })
 
-            const scene = state.sceneRef.current!
-            scene.remove(state.boxRef.current!)
-            const newBox = generateCustomBox(
-                grid,
-                state.wallThickness,
-                state.cornerRadius,
-                state.generateBottom
-            )
-            state.boxRef.current = newBox
-            newBox.position.set(
-                -useStore.getState().totalWidth / 2,
-                0,
-                -useStore.getState().totalDepth / 2
-            )
-            scene.add(newBox)
+            rebuildBoxFromCurrentState()
 
             selectedGroups = []
-            state.setSelectedGroups(selectedGroups)
+            currentState.setSelectedGroups(selectedGroups)
         }
 
         function onHideClick() {
-            if (selectedGroups.length === 0) return
+            const currentState = useStore.getState()
+            const groupsToHide = currentState.selectedGroups
+            if (groupsToHide.length === 0) return
 
-            const grid = state.gridRef.current!
+            const grid = currentState.gridRef.current
 
-            selectedGroups.forEach((grp) => {
+            groupsToHide.forEach((grp) => {
                 const box = grp.userData as {
                     cells: Array<{ x: number; z: number }>
                 }
                 setGridBoxVisible(grid, box, !isGridBoxVisible(grid, box))
             })
 
-            const scene = state.sceneRef.current!
-            scene.remove(state.boxRef.current!)
-            const newBox = generateCustomBox(
-                grid,
-                state.wallThickness,
-                state.cornerRadius,
-                state.generateBottom
-            )
-            state.boxRef.current = newBox
-            newBox.position.set(
-                -useStore.getState().totalWidth / 2,
-                0,
-                -useStore.getState().totalDepth / 2
-            )
-            scene.add(newBox)
+            rebuildBoxFromCurrentState()
 
             selectedGroups = []
-            state.setSelectedGroups(selectedGroups)
+            currentState.setSelectedGroups(selectedGroups)
         }
 
         function onPointerDown(event: MouseEvent) {
@@ -239,7 +229,7 @@ export default function Home() {
                 //@ts-ignore
                 const idx = object.parent.children.indexOf(object)
                 const isWall = idx === 0
-                const isBottom = state.generateBottom && idx === 1
+                const isBottom = useStore.getState().generateBottom && idx === 1
                 return isWall || isBottom
             })
             if (!hit) return
@@ -256,7 +246,7 @@ export default function Home() {
             } else {
                 selectedGroups.push(box)
             }
-            state.setSelectedGroups([...selectedGroups])
+            useStore.getState().setSelectedGroups([...selectedGroups])
         }
 
         renderer.domElement.addEventListener('pointerdown', onPointerDown)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import HiddenBoxesDisplay from '@/components/HiddenBoxesDisplay'
 import { generateCustomBox } from '@/lib/boxHelper'
 import { cameraSettings, material } from '@/lib/defaults'
 import { gridMatchesLayout, resizeGrid } from '@/lib/gridHelper'
+import { isGridBoxVisible, setGridBoxVisible } from '@/lib/gridVisibility'
 import { useStore } from '@/lib/store'
 import { useEffect } from 'react'
 import * as THREE from 'three'
@@ -118,23 +119,6 @@ export default function Home() {
             }
         }
 
-        const updateHiddenBoxIds = () => {
-            const currentBoxRef = state.boxRef.current
-            if (!currentBoxRef) return
-
-            const newHiddenIds = new Set<number>()
-            currentBoxRef.children.forEach((child) => {
-                if (
-                    child instanceof THREE.Group &&
-                    !child.visible &&
-                    child.userData.id
-                ) {
-                    newHiddenIds.add(child.userData.id)
-                }
-            })
-            state.setHiddenBoxIds(newHiddenIds)
-        }
-
         function onCombineClick() {
             if (selectedGroups.length < 2) return
 
@@ -172,7 +156,6 @@ export default function Home() {
 
             selectedGroups = []
             state.setSelectedGroups(selectedGroups)
-            updateHiddenBoxIds()
         }
 
         function onSplitClick() {
@@ -204,7 +187,6 @@ export default function Home() {
 
             selectedGroups = []
             state.setSelectedGroups(selectedGroups)
-            updateHiddenBoxIds()
         }
 
         function onHideClick() {
@@ -213,13 +195,10 @@ export default function Home() {
             const grid = state.gridRef.current!
 
             selectedGroups.forEach((grp) => {
-                const newVisibility = !grp.visible
-                grp.visible = newVisibility
-
-                const cells: { x: number; z: number }[] = grp.userData.cells
-                cells.forEach(({ x, z }) => {
-                    grid[z][x].visible = newVisibility
-                })
+                const box = grp.userData as {
+                    cells: Array<{ x: number; z: number }>
+                }
+                setGridBoxVisible(grid, box, !isGridBoxVisible(grid, box))
             })
 
             const scene = state.sceneRef.current!
@@ -240,7 +219,6 @@ export default function Home() {
 
             selectedGroups = []
             state.setSelectedGroups(selectedGroups)
-            updateHiddenBoxIds()
         }
 
         function onPointerDown(event: MouseEvent) {

--- a/components/HiddenBoxesDisplay.tsx
+++ b/components/HiddenBoxesDisplay.tsx
@@ -1,56 +1,37 @@
 'use client'
 
+import {
+    getGridBoxes,
+    setGridBoxVisible,
+    type GridBoxInfo,
+} from '@/lib/gridVisibility'
 import { useStore } from '@/lib/store'
 import { ChevronDown, ChevronUp, Eye } from 'lucide-react'
 import { useCallback, useState } from 'react'
-import * as THREE from 'three'
 
 export default function HiddenBoxesDisplay() {
-    const hiddenBoxIds = useStore((state) => state.hiddenBoxIds)
-    const setHiddenBoxIds = useStore((state) => state.setHiddenBoxIds)
     const store = useStore()
     const [isCollapsed, setIsCollapsed] = useState(false)
+    const hiddenBoxes = getGridBoxes(store.gridRef.current).filter(
+        (box) => !box.visible
+    )
 
-    const handleUnhideBox = (boxToUnhide: THREE.Group) => {
-        boxToUnhide.visible = true
-
-        const newHiddenBoxIds = new Set(hiddenBoxIds)
-        newHiddenBoxIds.delete(boxToUnhide.userData.id)
-
-        setHiddenBoxIds(newHiddenBoxIds)
+    const handleUnhideBox = (boxToUnhide: GridBoxInfo) => {
+        setGridBoxVisible(store.gridRef.current, boxToUnhide, true)
         store.forceRedraw()
     }
 
     const handleUnhideAll = useCallback(() => {
-        const currentBoxRef = store.boxRef.current
-        if (!currentBoxRef) return
-
-        for (const id of hiddenBoxIds) {
-            const box = currentBoxRef.children.find(
-                (child) => child.userData.id === id
-            ) as THREE.Group
-            if (box) {
-                box.visible = true
-            }
-        }
-
-        setHiddenBoxIds(new Set())
+        getGridBoxes(store.gridRef.current).forEach((box) => {
+            setGridBoxVisible(store.gridRef.current, box, true)
+        })
         store.setSelectedGroups([])
         store.forceRedraw()
-    }, [hiddenBoxIds, store])
+    }, [store])
 
-    if (hiddenBoxIds.size === 0) {
+    if (hiddenBoxes.length === 0) {
         return null
     }
-
-    const hiddenBoxes = Array.from(hiddenBoxIds)
-        .map(
-            (id) =>
-                store.boxRef.current?.children.find(
-                    (child) => child.userData.id === id
-                ) as THREE.Group | undefined
-        )
-        .filter(Boolean) as THREE.Group[]
 
     return (
         <div className="fixed right-4 top-20 z-50 min-w-[200px] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-80">
@@ -75,15 +56,13 @@ export default function HiddenBoxesDisplay() {
 
                     {hiddenBoxes.map((box) => (
                         <div
-                            key={box.userData.id}
+                            key={box.id}
                             className="relative flex cursor-default select-none items-center rounded-sm px-2 text-sm outline-none justify-between"
                             title="Unhide Box"
                         >
                             <span>
-                                Box {box.userData.id}
-                                {box.userData.group !== 0
-                                    ? ` (Group ${box.userData.group})`
-                                    : ''}
+                                Box {box.id}
+                                {box.group !== 0 ? ` (Group ${box.group})` : ''}
                             </span>
                             <button
                                 className="ml-auto inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 hover:bg-muted/50 h-8 w-8"
@@ -95,7 +74,7 @@ export default function HiddenBoxesDisplay() {
                         </div>
                     ))}
 
-                    {hiddenBoxIds.size > 1 && (
+                    {hiddenBoxes.length > 1 && (
                         <>
                             <div className="-mx-1 my-1 h-px bg-border" />
                             <div

--- a/lib/exportUtils.ts
+++ b/lib/exportUtils.ts
@@ -1,3 +1,5 @@
+import { generateCustomBox } from '@/lib/boxHelper'
+import { getGridBoxes } from '@/lib/gridVisibility'
 import { useStore } from '@/lib/store'
 import * as THREE from 'three'
 import { STLExporter } from 'three/examples/jsm/exporters/STLExporter.js'
@@ -7,15 +9,21 @@ import { STLExporter } from 'three/examples/jsm/exporters/STLExporter.js'
  */
 export function handleStlExport(): void {
     const state = useStore.getState()
-    const origScene = state.sceneRef.current
-    if (!origScene) return
+    const grid = state.gridRef.current
+    if (grid.length === 0) return
 
     // Wrap & rotate so Three's Y-up becomes STL Z-up
     const tmpScene = new THREE.Scene()
-    const sceneClone = origScene.clone(true)
-    sceneClone.position.set(0, 0, 0)
-    sceneClone.rotation.set(Math.PI / 2, 0, 0)
-    tmpScene.add(sceneClone)
+    const box = generateCustomBox(
+        grid,
+        state.wallThickness,
+        state.cornerRadius,
+        state.generateBottom
+    )
+    removeHiddenObjects(box)
+    box.position.set(0, 0, 0)
+    box.rotation.set(Math.PI / 2, 0, 0)
+    tmpScene.add(box)
     tmpScene.updateMatrixWorld()
 
     const exporter = new STLExporter()
@@ -48,6 +56,7 @@ export async function handleExportMultipleSTLs(): Promise<void> {
 
     const boxWidths = grid[0].map((cell) => cell.width)
     const boxDepths = grid.map((row) => row[0].depth)
+    const gridBoxes = getGridBoxes(grid)
 
     // group boxes by dimensions (ignoring width↔depth swap)
     type GroupInfo = {
@@ -61,7 +70,7 @@ export async function handleExportMultipleSTLs(): Promise<void> {
     const groups = new Map<string, GroupInfo>()
 
     boxGroup.children.forEach((box, idx) => {
-        if (!box.visible) return
+        if (gridBoxes[idx]?.visible === false) return
 
         const ud = (box.userData.dimensions || {}) as {
             width?: number
@@ -152,4 +161,15 @@ Happy printing!
     link.click()
     document.body.removeChild(link)
     setTimeout(() => URL.revokeObjectURL(link.href), 100)
+}
+
+function removeHiddenObjects(object: THREE.Object3D): void {
+    for (const child of [...object.children]) {
+        if (!child.visible) {
+            object.remove(child)
+            continue
+        }
+
+        removeHiddenObjects(child)
+    }
 }

--- a/lib/gridVisibility.ts
+++ b/lib/gridVisibility.ts
@@ -1,0 +1,78 @@
+import { Grid } from '@/lib/types'
+
+export type GridBoxInfo = {
+    id: number
+    group: number
+    cells: Array<{ x: number; z: number }>
+    visible: boolean
+}
+
+export function getGridBoxes(grid: Grid): GridBoxInfo[] {
+    if (grid.length === 0) return []
+
+    let nextBoxId = 1
+    const boxes: GridBoxInfo[] = []
+    const groupIds = Array.from(new Set(grid.flat().map((cell) => cell.group)))
+        .filter((group) => group > 0)
+        .sort((a, b) => a - b)
+
+    groupIds.forEach((group) => {
+        const cells = getCellsForGroup(grid, group)
+        boxes.push({
+            id: nextBoxId++,
+            group,
+            cells,
+            visible: cells.some(({ x, z }) => grid[z][x].visible !== false),
+        })
+    })
+
+    for (let z = 0; z < grid.length; z++) {
+        for (let x = 0; x < grid[0].length; x++) {
+            const cell = grid[z][x]
+            if (cell.group !== 0) continue
+
+            boxes.push({
+                id: nextBoxId++,
+                group: 0,
+                cells: [{ x, z }],
+                visible: cell.visible !== false,
+            })
+        }
+    }
+
+    return boxes
+}
+
+export function setGridBoxVisible(
+    grid: Grid,
+    box: Pick<GridBoxInfo, 'cells'>,
+    visible: boolean
+): void {
+    box.cells.forEach(({ x, z }) => {
+        grid[z][x].visible = visible
+    })
+}
+
+export function isGridBoxVisible(
+    grid: Grid,
+    box: Pick<GridBoxInfo, 'cells'>
+): boolean {
+    return box.cells.some(({ x, z }) => grid[z][x].visible !== false)
+}
+
+function getCellsForGroup(
+    grid: Grid,
+    group: number
+): Array<{ x: number; z: number }> {
+    const cells: Array<{ x: number; z: number }> = []
+
+    for (let z = 0; z < grid.length; z++) {
+        for (let x = 0; x < grid[0].length; x++) {
+            if (grid[z][x].group === group) {
+                cells.push({ x, z })
+            }
+        }
+    }
+
+    return cells
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -38,9 +38,6 @@ export const useStore = create<StoreState>((set) => ({
     // Helpers
     selectedGroups: [] as THREE.Group[],
     setSelectedGroups: (groups) => set({ selectedGroups: groups }),
-    hiddenBoxIds: new Set<number>(),
-    setHiddenBoxIds: (ids: Set<number>) => set({ hiddenBoxIds: ids }),
-
     // General
     showHelperGrid: true,
     setShowHelperGrid: (show: boolean) => set({ showHelperGrid: show }),

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -44,8 +44,6 @@ export interface StoreState {
     // Helpers
     selectedGroups: THREE.Group[]
     setSelectedGroups: (groups: THREE.Group[]) => void
-    hiddenBoxIds: Set<number>
-    setHiddenBoxIds: (ids: Set<number>) => void
 
     // General
     actionsBarPosition: 'top' | 'bottom'


### PR DESCRIPTION
## Changed
- Moved hidden box state to the grid/domain model instead of keeping generated Three.js object IDs in the store.
- Updated the hidden boxes panel to derive hidden entries from grid cells and unhide by updating the grid.
- Updated exports to respect grid-backed visibility, including single STL export.
- Fixed keyboard hide/combine/split redraws to read the latest store state before regenerating geometry.

## Why
- Three.js objects are regenerated during redraws and setting changes, so storing hidden state there can be lost or drift from the model.
- Keeping visibility on grid cells makes hide/unhide survive redraws, model setting changes, and export flows.
- The keyboard hide handler was closing over stale wall thickness/corner radius values from mount, so hiding after dimension/max-box edits could redraw with old geometry settings.

## Validation
- `npx tsc --noEmit`
- `npm run lint` passes with existing hook dependency warnings only
- `npx next build`
- Browser smoke test: set wall thickness to 5, corner radius to 8, changed total width, hid via `h`, then unhid from the hidden box panel; wall/radius stayed 5/8 throughout.