### PR TITLE
TW-208 Add geometry unit tests

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import BoxContextMenu from '@/components/BoxContextMenu'
 import HiddenBoxesDisplay from '@/components/HiddenBoxesDisplay'
 import { generateCustomBox } from '@/lib/boxHelper'
 import { cameraSettings, material } from '@/lib/defaults'
+import { combineGridBoxes, getNextAvailableGroupId } from '@/lib/gridCombine'
 import { gridMatchesLayout, resizeGrid } from '@/lib/gridHelper'
 import { isGridBoxVisible, setGridBoxVisible } from '@/lib/gridVisibility'
 import { useStore } from '@/lib/store'
@@ -150,21 +151,9 @@ export default function Home() {
             const currentBox = currentState.boxRef.current
             if (!currentBox) return
 
-            const existing = new Set<number>(
-                (currentBox.children as THREE.Group[]).map(
-                    (g) => g.userData.group as number
-                )
-            )
-            let newId = 1
-            while (existing.has(newId)) newId++
-
             const grid = currentState.gridRef.current
-            groupsToCombine.forEach((grp) => {
-                const cells: { x: number; z: number }[] = grp.userData.cells
-                cells.forEach(({ x, z }) => {
-                    grid[z][x].group = newId
-                })
-            })
+            const newId = getNextAvailableGroupId(grid)
+            if (!combineGridBoxes(grid, groupsToCombine, newId)) return
 
             rebuildBoxFromCurrentState()
 

--- a/components/ActionsBar.tsx
+++ b/components/ActionsBar.tsx
@@ -16,6 +16,7 @@ import {
     TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { cameraSettings } from '@/lib/defaults'
+import { canCombineGridBoxes } from '@/lib/gridCombine'
 import { keyPress } from '@/lib/keyHelper'
 import { useStore } from '@/lib/store'
 import {
@@ -44,6 +45,11 @@ export default function ActionsBar() {
     const [enableClearSelection, setEnableClearSelection] = useState(false)
     const [canSplit, setCanSplit] = useState(false)
 
+    const canCombine =
+        store.selectedGroups.length >= 2 &&
+        canCombineGridBoxes(store.gridRef.current, store.selectedGroups)
+    const canUseBoxAction = canSplit || canCombine
+
     const resetCamera = () => {
         if (!camera.current || !controls.current) return
 
@@ -70,12 +76,15 @@ export default function ActionsBar() {
             if (store.selectedGroups.length == 1) {
                 if (store.selectedGroups[0].userData.group != 0) {
                     setCanSplit(true)
+                } else {
+                    setCanSplit(false)
                 }
             } else {
                 setCanSplit(false)
             }
         } else {
             setEnableClearSelection(false)
+            setCanSplit(false)
         }
     }, [store.selectedGroups])
 
@@ -145,15 +154,15 @@ export default function ActionsBar() {
                         <TooltipTrigger
                             className={
                                 'flex h-8 w-8 items-center justify-center rounded-md hover:bg-neutral-100' +
-                                (enableClearSelection
+                                (canUseBoxAction
                                     ? ' cursor-pointer'
                                     : ' cursor-not-allowed text-neutral-400')
                             }
-                            disabled={!enableClearSelection}
+                            disabled={!canUseBoxAction}
                             onClick={() => {
                                 if (canSplit) {
                                     keyPress('s')
-                                } else {
+                                } else if (canCombine) {
                                     keyPress('c')
                                 }
                             }}

--- a/components/BoxContextMenu.tsx
+++ b/components/BoxContextMenu.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { canCombineGridBoxes } from '@/lib/gridCombine'
 import { keyPress } from '@/lib/keyHelper'
 import { useStore } from '@/lib/store'
 import { BoxInfo } from '@/lib/types'
@@ -29,6 +30,7 @@ export default function BoxContextMenu() {
     const storeContainerRef = useStore((state) => state.containerRef)
     const cameraRef = useStore((state) => state.cameraRef)
     const boxRef = useStore((state) => state.boxRef)
+    const gridRef = useStore((state) => state.gridRef)
     const setSelectedGroups = useStore((state) => state.setSelectedGroups)
     const selectedGroups = useStore((state) => state.selectedGroups)
 
@@ -187,7 +189,9 @@ export default function BoxContextMenu() {
         boxInfos &&
         selectedGroups.some((group) => group.userData.id === boxInfos.id)
 
-    const canCombine = selectedGroups.length >= 2
+    const canCombine =
+        selectedGroups.length >= 2 &&
+        canCombineGridBoxes(gridRef.current, selectedGroups)
 
     if (selectedGroups.length === 0) {
         // if no boxes are selected, don't show the menu

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,8 +1,16 @@
 import nextVitals from 'eslint-config-next/core-web-vitals'
 
 const eslintConfig = [
+    {
+        ignores: ['*.config.mjs'],
+    },
     ...nextVitals,
     {
+        settings: {
+            react: {
+                version: '19.2.7',
+            },
+        },
         rules: {
             'react/no-unescaped-entities': 'off',
             '@next/next/no-page-custom-font': 'off',

--- a/lib/boxHelper.ts
+++ b/lib/boxHelper.ts
@@ -14,6 +14,10 @@ export function generateCustomBox(
     corner_radius: number,
     generate_bottom: boolean
 ): THREE.Group {
+    if (grid.length === 0 || grid[0].length === 0) {
+        throw new Error('Cannot generate box geometry for an empty grid.')
+    }
+
     const group = new THREE.Group()
     const ids = Array.from(new Set(grid.flat().map((c) => c.group))).filter(
         (i) => i > 0

--- a/lib/gridCombine.ts
+++ b/lib/gridCombine.ts
@@ -1,0 +1,72 @@
+import { getOutline } from '@/lib/lineHelper'
+import { Grid } from '@/lib/types'
+
+export type GridBoxSelection = {
+    cells?: Array<{ x: number; z: number }>
+    userData?: {
+        cells?: Array<{ x: number; z: number }>
+    }
+}
+
+export function canCombineGridBoxes(
+    grid: Grid,
+    boxes: GridBoxSelection[]
+): boolean {
+    if (boxes.length < 2 || grid.length === 0 || grid[0].length === 0) {
+        return false
+    }
+
+    const nextGroup = getNextAvailableGroupId(grid)
+    const candidate = grid.map((row) => row.map((cell) => ({ ...cell })))
+    const selectedCells = selectedCellKeys(boxes)
+
+    if (selectedCells.size === 0) return false
+
+    for (const key of selectedCells) {
+        const [x, z] = key.split(',').map(Number)
+        if (!candidate[z]?.[x]) return false
+        candidate[z][x].group = nextGroup
+    }
+
+    try {
+        getOutline(candidate, nextGroup)
+        return true
+    } catch {
+        return false
+    }
+}
+
+export function combineGridBoxes(
+    grid: Grid,
+    boxes: GridBoxSelection[],
+    groupId: number
+): boolean {
+    if (!canCombineGridBoxes(grid, boxes)) return false
+
+    selectedCellKeys(boxes).forEach((key) => {
+        const [x, z] = key.split(',').map(Number)
+        grid[z][x].group = groupId
+    })
+    return true
+}
+
+export function getNextAvailableGroupId(grid: Grid): number {
+    const existing = new Set(grid.flat().map((cell) => cell.group))
+    let nextGroup = 1
+    while (existing.has(nextGroup)) nextGroup++
+    return nextGroup
+}
+
+function selectedCellKeys(boxes: GridBoxSelection[]): Set<string> {
+    return new Set(
+        boxes.flatMap((box) =>
+            getSelectionCells(box).map(({ x, z }) => `${x},${z}`)
+        )
+    )
+}
+
+function getSelectionCells(
+    box: GridBoxSelection
+): Array<{ x: number; z: number }> {
+    return box.cells ?? box.userData?.cells ?? []
+}

--- a/lib/lineHelper.ts
+++ b/lib/lineHelper.ts
@@ -2,6 +2,10 @@ import { Grid } from '@/lib/types'
 import * as THREE from 'three'
 
 export function getOutline(grid: Grid, groupId: number): THREE.Vector2[] {
+    if (grid.length === 0 || grid[0].length === 0) {
+        throw new Error('Cannot build an outline for an empty grid.')
+    }
+
     const rows = grid.length
     const cols = grid[0].length
 
@@ -44,6 +48,10 @@ export function getOutline(grid: Grid, groupId: number): THREE.Vector2[] {
         }
     }
 
+    if (segs.length === 0) {
+        throw new Error(`Cannot build an outline for missing group ${groupId}.`)
+    }
+
     const loop: THREE.Vector2[] = []
     let cur = segs.shift()!
     loop.push(cur.a, cur.b)
@@ -57,6 +65,12 @@ export function getOutline(grid: Grid, groupId: number): THREE.Vector2[] {
     if (loop.length > 1 && loop[0].equals(loop[loop.length - 1])) {
         loop.pop()
     }
+    if (segs.length > 0) {
+        throw new Error(
+            `Cannot build a single outline for group ${groupId} with disconnected cells or holes.`
+        )
+    }
+
     return loop.map((p) => new THREE.Vector2(cumW[p.x], cumD[p.y]))
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,8 @@
                 "prettier": "^3.9.4",
                 "prettier-plugin-tailwindcss": "^0.8.0",
                 "tailwindcss": "^4.3.2",
-                "typescript": "^6.0.3"
+                "typescript": "^6.0.3",
+                "vitest": "^4.1.10"
             },
             "engines": {
                 "node": "24.x",
@@ -1153,6 +1154,25 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+            "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@tybys/wasm-util": "^0.10.3"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
+            }
+        },
         "node_modules/@next/env": {
             "version": "16.2.10",
             "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
@@ -1208,9 +1228,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1226,9 +1243,6 @@
             "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -1246,9 +1260,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1264,9 +1275,6 @@
             "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -1355,6 +1363,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=12.4.0"
+            }
+        },
+        "node_modules/@oxc-project/types": {
+            "version": "0.139.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+            "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
             }
         },
         "node_modules/@radix-ui/number": {
@@ -2346,10 +2364,315 @@
             "integrity": "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==",
             "license": "MIT"
         },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+            "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+            "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+            "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+            "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+            "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+            "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+            "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+            "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+            "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+            "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+            "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+            "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+            "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.11.1",
+                "@emnapi/runtime": "1.11.1",
+                "@napi-rs/wasm-runtime": "^1.1.6"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.2",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+            "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+            "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+            "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@rtsao/scc": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
             "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
             "dev": true,
             "license": "MIT"
         },
@@ -2494,9 +2817,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2514,9 +2834,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2534,9 +2851,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2554,9 +2868,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2714,6 +3025,35 @@
             "version": "23.1.3",
             "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
             "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="
+        },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/esrecurse": {
             "version": "4.3.1",
@@ -2966,9 +3306,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2983,9 +3320,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3000,9 +3334,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3017,9 +3348,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3034,9 +3362,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3051,9 +3376,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3068,9 +3390,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3085,9 +3404,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3102,9 +3418,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3119,9 +3432,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3159,36 +3469,6 @@
             },
             "engines": {
                 "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-            "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@tybys/wasm-util": "^0.10.3"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            },
-            "peerDependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1"
-            }
-        },
-        "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@tybys/wasm-util": {
-            "version": "0.10.3",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
             }
         },
         "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
@@ -3232,6 +3512,119 @@
             "os": [
                 "win32"
             ]
+        },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+            "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+            "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.10",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+            "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+            "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.10",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+            "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+            "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+            "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
         },
         "node_modules/acorn": {
             "version": "8.17.0",
@@ -3456,6 +3849,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/ast-types-flow": {
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -3659,6 +4062,16 @@
                 }
             ],
             "license": "CC-BY-4.0"
+        },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/class-variance-authority": {
             "version": "0.7.1",
@@ -4023,6 +4436,13 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+            "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
@@ -4856,6 +5276,16 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4863,6 +5293,16 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+            "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/fast-deep-equal": {
@@ -5002,6 +5442,21 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
         "node_modules/function-bind": {
@@ -6051,9 +6506,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -6075,9 +6527,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -6099,9 +6548,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -6123,9 +6569,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -6572,6 +7015,20 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/obug": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+            "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20.0"
+            }
+        },
         "node_modules/optionator": {
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6684,6 +7141,13 @@
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true
+        },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
@@ -7119,6 +7583,40 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/rolldown": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+            "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "=0.139.0",
+                "@rolldown/pluginutils": "^1.0.0"
+            },
+            "bin": {
+                "rolldown": "bin/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "optionalDependencies": {
+                "@rolldown/binding-android-arm64": "1.1.5",
+                "@rolldown/binding-darwin-arm64": "1.1.5",
+                "@rolldown/binding-darwin-x64": "1.1.5",
+                "@rolldown/binding-freebsd-x64": "1.1.5",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+                "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+                "@rolldown/binding-linux-arm64-musl": "1.1.5",
+                "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+                "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-musl": "1.1.5",
+                "@rolldown/binding-openharmony-arm64": "1.1.5",
+                "@rolldown/binding-wasm32-wasi": "1.1.5",
+                "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+                "@rolldown/binding-win32-x64-msvc": "1.1.5"
+            }
+        },
         "node_modules/run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7420,6 +7918,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/sonner": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
@@ -7442,6 +7947,20 @@
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
             "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
             "dev": true,
             "license": "MIT"
         },
@@ -7686,15 +8205,32 @@
                 "three": ">= 0.154.0"
             }
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+            "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/tinyglobby": {
-            "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -7732,6 +8268,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/to-regex-range": {
@@ -8041,6 +8587,200 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
         },
+        "node_modules/vite": {
+            "version": "8.1.4",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+            "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.5",
+                "postcss": "^8.5.16",
+                "rolldown": "~1.1.4",
+                "tinyglobby": "^0.2.17"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.3.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/vitest": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+            "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.1.10",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/runner": "4.1.10",
+                "@vitest/snapshot": "4.1.10",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.10",
+                "@vitest/browser-preview": "4.1.10",
+                "@vitest/browser-webdriverio": "4.1.10",
+                "@vitest/coverage-istanbul": "4.1.10",
+                "@vitest/coverage-v8": "4.1.10",
+                "@vitest/ui": "4.1.10",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8145,6 +8885,23 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "build": "prettier --write . && next build",
         "start": "next start",
         "lint": "eslint .",
+        "test": "vitest run",
         "format": "prettier --write ."
     },
     "dependencies": {
@@ -59,7 +60,8 @@
         "prettier": "^3.9.4",
         "prettier-plugin-tailwindcss": "^0.8.0",
         "tailwindcss": "^4.3.2",
-        "typescript": "^6.0.3"
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.10"
     },
     "overrides": {
         "postcss": "^8.5.16"

--- a/tests/geometry.test.ts
+++ b/tests/geometry.test.ts
@@ -1,0 +1,529 @@
+import { generateCustomBox } from '@/lib/boxHelper'
+import {
+    canCombineGridBoxes,
+    combineGridBoxes,
+    getNextAvailableGroupId,
+} from '@/lib/gridCombine'
+import { gridMatchesLayout, resizeGrid } from '@/lib/gridHelper'
+import {
+    getGridBoxes,
+    isGridBoxVisible,
+    setGridBoxVisible,
+} from '@/lib/gridVisibility'
+import { getOutline } from '@/lib/lineHelper'
+import { sanitizeModelParameters } from '@/lib/parameterValidation'
+import { useStore } from '@/lib/store'
+import { Grid } from '@/lib/types'
+import * as THREE from 'three'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+function points(outline: ReturnType<typeof getOutline>): string[] {
+    return outline.map((point) => `${point.x},${point.y}`)
+}
+
+function signedArea(outline: ReturnType<typeof getOutline>): number {
+    return outline.reduce((sum, point, index) => {
+        const next = outline[(index + 1) % outline.length]
+        return sum + point.x * next.y - next.x * point.y
+    }, 0)
+}
+
+function meshes(object: THREE.Object3D): THREE.Mesh[] {
+    const result: THREE.Mesh[] = []
+    object.traverse((child) => {
+        if (child instanceof THREE.Mesh) result.push(child)
+    })
+    return result
+}
+
+function expectFiniteGeometry(object: THREE.Object3D): void {
+    const objectMeshes = meshes(object)
+    expect(objectMeshes.length).toBeGreaterThan(0)
+
+    objectMeshes.forEach((mesh) => {
+        const position = mesh.geometry.getAttribute('position')
+        expect(position.count).toBeGreaterThan(0)
+
+        for (let index = 0; index < position.count; index++) {
+            expect(Number.isFinite(position.getX(index))).toBe(true)
+            expect(Number.isFinite(position.getY(index))).toBe(true)
+            expect(Number.isFinite(position.getZ(index))).toBe(true)
+        }
+    })
+}
+
+function boundingSize(object: THREE.Object3D): THREE.Vector3 {
+    object.updateMatrixWorld(true)
+
+    const box = new THREE.Box3().setFromObject(object)
+    const size = new THREE.Vector3()
+    box.getSize(size)
+    return size
+}
+
+function footprintPoints(object: THREE.Object3D): Set<string> {
+    object.updateMatrixWorld(true)
+
+    const footprint = new Set<string>()
+    meshes(object).forEach((mesh) => {
+        const position = mesh.geometry.getAttribute('position')
+        const vector = new THREE.Vector3()
+
+        for (let index = 0; index < position.count; index++) {
+            vector
+                .set(
+                    position.getX(index),
+                    position.getY(index),
+                    position.getZ(index)
+                )
+                .applyMatrix4(mesh.matrixWorld)
+            footprint.add(`${Math.round(vector.x)},${Math.round(vector.z)}`)
+        }
+    })
+
+    return footprint
+}
+
+function hasFootprintPoint(
+    footprint: Set<string>,
+    predicate: (x: number, z: number) => boolean
+): boolean {
+    return Array.from(footprint).some((point) => {
+        const [x, z] = point.split(',').map(Number)
+        return predicate(x, z)
+    })
+}
+
+function projectedTriangleArea(mesh: THREE.Mesh): number {
+    mesh.updateMatrixWorld(true)
+
+    const position = mesh.geometry.getAttribute('position')
+    const index = mesh.geometry.getIndex()
+    const vertex = new THREE.Vector3()
+    const triangle: THREE.Vector3[] = [
+        new THREE.Vector3(),
+        new THREE.Vector3(),
+        new THREE.Vector3(),
+    ]
+    let area = 0
+
+    const readVertex = (vertexIndex: number, target: THREE.Vector3) => {
+        target
+            .set(
+                position.getX(vertexIndex),
+                position.getY(vertexIndex),
+                position.getZ(vertexIndex)
+            )
+            .applyMatrix4(mesh.matrixWorld)
+    }
+
+    const triangleCount = (index?.count ?? position.count) / 3
+    for (
+        let triangleIndex = 0;
+        triangleIndex < triangleCount;
+        triangleIndex++
+    ) {
+        for (let corner = 0; corner < 3; corner++) {
+            const rawIndex = triangleIndex * 3 + corner
+            readVertex(index ? index.getX(rawIndex) : rawIndex, vertex)
+            triangle[corner].copy(vertex)
+        }
+
+        area +=
+            Math.abs(
+                triangle[0].x * (triangle[1].z - triangle[2].z) +
+                    triangle[1].x * (triangle[2].z - triangle[0].z) +
+                    triangle[2].x * (triangle[0].z - triangle[1].z)
+            ) / 2
+    }
+
+    return area
+}
+
+describe('geometry outlines', () => {
+    it('builds the outline for a rectangular cell', () => {
+        const grid: Grid = [[{ group: 0, width: 30, depth: 20 }]]
+
+        const outline = getOutline(grid, 0)
+
+        expect(points(outline)).toEqual(['0,0', '30,0', '30,20', '0,20'])
+        expect(outline[0].equals(outline[outline.length - 1])).toBe(false)
+        expect(new Set(points(outline)).size).toBe(outline.length)
+        expect(signedArea(outline)).toBeGreaterThan(0)
+    })
+
+    it('builds the ordered outline for an L-shaped combined box', () => {
+        const grid: Grid = [
+            [
+                { group: 1, width: 10, depth: 30 },
+                { group: 1, width: 20, depth: 30 },
+            ],
+            [
+                { group: 1, width: 10, depth: 40 },
+                { group: 0, width: 20, depth: 40 },
+            ],
+        ]
+
+        const outline = getOutline(grid, 1)
+
+        expect(points(outline)).toEqual([
+            '0,0',
+            '10,0',
+            '30,0',
+            '30,30',
+            '10,30',
+            '10,70',
+            '0,70',
+            '0,30',
+        ])
+        expect(outline[0].equals(outline[outline.length - 1])).toBe(false)
+        expect(new Set(points(outline)).size).toBe(outline.length)
+        expect(signedArea(outline)).toBeGreaterThan(0)
+    })
+
+    it('rejects disconnected cells that share one group id', () => {
+        const grid: Grid = [
+            [
+                { group: 9, width: 10, depth: 10 },
+                { group: 0, width: 10, depth: 10 },
+                { group: 9, width: 10, depth: 10 },
+            ],
+        ]
+
+        expect(() => getOutline(grid, 9)).toThrow(
+            'Cannot build a single outline for group 9 with disconnected cells or holes.'
+        )
+    })
+
+    it('rejects holed groups that need multiple outline loops', () => {
+        const grid: Grid = [
+            [
+                { group: 8, width: 10, depth: 10 },
+                { group: 8, width: 10, depth: 10 },
+                { group: 8, width: 10, depth: 10 },
+            ],
+            [
+                { group: 8, width: 10, depth: 10 },
+                { group: 0, width: 10, depth: 10 },
+                { group: 8, width: 10, depth: 10 },
+            ],
+            [
+                { group: 8, width: 10, depth: 10 },
+                { group: 8, width: 10, depth: 10 },
+                { group: 8, width: 10, depth: 10 },
+            ],
+        ]
+
+        expect(() => getOutline(grid, 8)).toThrow(
+            'Cannot build a single outline for group 8 with disconnected cells or holes.'
+        )
+    })
+})
+
+describe('box generation', () => {
+    beforeEach(() => {
+        useStore.setState({ wallHeight: 30, showCornerLines: false })
+    })
+
+    it('generates valid wall and bottom meshes for rectangular boxes', () => {
+        const grid: Grid = [[{ group: 0, width: 30, depth: 20 }]]
+        const box = generateCustomBox(grid, 2, 4, true)
+        const cell = box.children[0]
+        const size = boundingSize(cell)
+
+        expect(box.children).toHaveLength(1)
+        expect(meshes(cell)).toHaveLength(2)
+        expect(cell.visible).toBe(true)
+        expect(cell.userData.dimensions).toMatchObject({
+            width: 30,
+            depth: 20,
+        })
+        expect(size.x).toBeCloseTo(30)
+        expect(size.y).toBeCloseTo(30)
+        expect(size.z).toBeCloseTo(20)
+        expectFiniteGeometry(cell)
+    })
+
+    it('omits bottom geometry when bottom generation is disabled', () => {
+        const grid: Grid = [[{ group: 0, width: 30, depth: 20 }]]
+
+        expect(meshes(generateCustomBox(grid, 2, 4, false))).toHaveLength(1)
+        expect(meshes(generateCustomBox(grid, 2, 4, true))).toHaveLength(2)
+    })
+
+    it('generates one box for combined cells and split boxes after ungrouping', () => {
+        const grid: Grid = [
+            [
+                { group: 4, width: 25, depth: 40 },
+                { group: 4, width: 35, depth: 40 },
+            ],
+        ]
+        const combined = generateCustomBox(grid, 2, 4, false)
+
+        expect(combined.children).toHaveLength(1)
+        expect(combined.children[0].userData.group).toBe(4)
+        expect(combined.children[0].userData.dimensions).toMatchObject({
+            width: 60,
+            depth: 40,
+        })
+
+        grid[0][0].group = 0
+        grid[0][1].group = 0
+        const split = generateCustomBox(grid, 2, 4, false)
+
+        expect(split.children).toHaveLength(2)
+        expect(split.children.map((child) => child.userData.group)).toEqual([
+            0, 0,
+        ])
+        expect(
+            split.children.map((child) => child.userData.dimensions.width)
+        ).toEqual([25, 35])
+        split.children.forEach(expectFiniteGeometry)
+    })
+
+    it('generates finite mesh geometry for non-uniform L-shaped groups', () => {
+        const grid: Grid = [
+            [
+                { group: 7, width: 10, depth: 30 },
+                { group: 7, width: 20, depth: 30 },
+            ],
+            [
+                { group: 7, width: 10, depth: 40 },
+                { group: 0, width: 20, depth: 40 },
+            ],
+        ]
+        const box = generateCustomBox(grid, 2, 0, true)
+        const combined = box.children.find(
+            (child) => child.userData.group === 7
+        )
+
+        expect(combined).toBeDefined()
+        expect(meshes(combined!)).toHaveLength(2)
+        expect(combined?.userData.cells).toEqual([
+            { x: 0, z: 0 },
+            { x: 1, z: 0 },
+            { x: 0, z: 1 },
+        ])
+        expect(combined?.userData.dimensions).toMatchObject({
+            width: 30,
+            depth: 70,
+        })
+
+        const size = boundingSize(combined!)
+        expect(size.x).toBeCloseTo(30)
+        expect(size.y).toBeCloseTo(30)
+        expect(size.z).toBeCloseTo(70)
+        expectFiniteGeometry(combined!)
+
+        const combinedMeshes = meshes(combined!)
+        const bottomMesh = combinedMeshes[1]
+        expect(projectedTriangleArea(bottomMesh) / 2).toBeCloseTo(1300)
+
+        const footprint = footprintPoints(combined!)
+        expect(hasFootprintPoint(footprint, (x, z) => x >= 28 && z <= 30)).toBe(
+            true
+        )
+        expect(hasFootprintPoint(footprint, (x, z) => x <= 10 && z >= 68)).toBe(
+            true
+        )
+        expect(
+            hasFootprintPoint(
+                footprint,
+                (x, z) => x >= 8 && x <= 12 && z >= 28 && z <= 32
+            )
+        ).toBe(true)
+        expect(hasFootprintPoint(footprint, (x, z) => x >= 28 && z >= 68)).toBe(
+            false
+        )
+    })
+
+    it('rejects disconnected combined groups before mesh generation', () => {
+        const grid: Grid = [
+            [
+                { group: 6, width: 20, depth: 20 },
+                { group: 0, width: 20, depth: 20 },
+                { group: 6, width: 20, depth: 20 },
+            ],
+        ]
+
+        expect(() => generateCustomBox(grid, 2, 0, true)).toThrow(
+            'Cannot build a single outline for group 6 with disconnected cells or holes.'
+        )
+    })
+})
+
+describe('grid combine policy', () => {
+    it('combines adjacent selected boxes before geometry generation', () => {
+        const grid: Grid = [
+            [
+                { group: 0, width: 20, depth: 20 },
+                { group: 0, width: 20, depth: 20 },
+            ],
+        ]
+        const boxes = [{ cells: [{ x: 0, z: 0 }] }, { cells: [{ x: 1, z: 0 }] }]
+
+        expect(canCombineGridBoxes(grid, boxes)).toBe(true)
+        expect(
+            combineGridBoxes(grid, boxes, getNextAvailableGroupId(grid))
+        ).toBe(true)
+        expect(grid[0].map((cell) => cell.group)).toEqual([1, 1])
+    })
+
+    it('rejects disconnected selected boxes without mutating the grid', () => {
+        const grid: Grid = [
+            [
+                { group: 0, width: 20, depth: 20 },
+                { group: 0, width: 20, depth: 20 },
+                { group: 0, width: 20, depth: 20 },
+            ],
+        ]
+        const boxes = [{ cells: [{ x: 0, z: 0 }] }, { cells: [{ x: 2, z: 0 }] }]
+
+        expect(canCombineGridBoxes(grid, boxes)).toBe(false)
+        expect(combineGridBoxes(grid, boxes, 1)).toBe(false)
+        expect(grid[0].map((cell) => cell.group)).toEqual([0, 0, 0])
+    })
+
+    it('rejects holed selected boxes without mutating the grid', () => {
+        const grid: Grid = [
+            [
+                { group: 0, width: 10, depth: 10 },
+                { group: 0, width: 10, depth: 10 },
+                { group: 0, width: 10, depth: 10 },
+            ],
+            [
+                { group: 0, width: 10, depth: 10 },
+                { group: 0, width: 10, depth: 10 },
+                { group: 0, width: 10, depth: 10 },
+            ],
+            [
+                { group: 0, width: 10, depth: 10 },
+                { group: 0, width: 10, depth: 10 },
+                { group: 0, width: 10, depth: 10 },
+            ],
+        ]
+        const boxes = [
+            { cells: [{ x: 0, z: 0 }] },
+            { cells: [{ x: 1, z: 0 }] },
+            { cells: [{ x: 2, z: 0 }] },
+            { cells: [{ x: 0, z: 1 }] },
+            { cells: [{ x: 2, z: 1 }] },
+            { cells: [{ x: 0, z: 2 }] },
+            { cells: [{ x: 1, z: 2 }] },
+            { cells: [{ x: 2, z: 2 }] },
+        ]
+
+        expect(canCombineGridBoxes(grid, boxes)).toBe(false)
+        expect(combineGridBoxes(grid, boxes, 1)).toBe(false)
+        expect(grid.flat().map((cell) => cell.group)).toEqual(Array(9).fill(0))
+    })
+})
+
+describe('grid visibility', () => {
+    it('uses grid cells as the visibility source of truth', () => {
+        const grid: Grid = [
+            [
+                { group: 3, width: 20, depth: 20 },
+                { group: 3, width: 20, depth: 20 },
+            ],
+        ]
+        const [box] = getGridBoxes(grid)
+
+        expect(isGridBoxVisible(grid, box)).toBe(true)
+
+        setGridBoxVisible(grid, box, false)
+        expect(grid[0].map((cell) => cell.visible)).toEqual([false, false])
+        expect(getGridBoxes(grid)[0].visible).toBe(false)
+        expect(generateCustomBox(grid, 2, 4, true).children[0].visible).toBe(
+            false
+        )
+
+        setGridBoxVisible(grid, box, true)
+        expect(getGridBoxes(grid)[0].visible).toBe(true)
+    })
+
+    it('handles empty grids as an edge case', () => {
+        expect(getGridBoxes([])).toEqual([])
+    })
+
+    it('documents empty grids as invalid for lower-level geometry builders', () => {
+        expect(() => getOutline([], 0)).toThrow(
+            'Cannot build an outline for an empty grid.'
+        )
+        expect(() => generateCustomBox([], 2, 4, true)).toThrow(
+            'Cannot generate box geometry for an empty grid.'
+        )
+    })
+})
+
+describe('grid resizing', () => {
+    it('preserves group and visibility while resizing physical dimensions', () => {
+        const oldGrid: Grid = [
+            [
+                { group: 1, visible: false, width: 50, depth: 50 },
+                { group: 0, width: 50, depth: 50 },
+            ],
+            [
+                { group: 2, width: 50, depth: 50 },
+                { group: 0, width: 50, depth: 50 },
+            ],
+        ]
+
+        const resized = resizeGrid(oldGrid, 180, 120, 100, 100)
+
+        expect(resized).toHaveLength(2)
+        expect(resized[0]).toHaveLength(2)
+        expect(resized[0][0]).toMatchObject({
+            group: 1,
+            visible: false,
+            width: 100,
+            depth: 100,
+        })
+        expect(resized[0][1]).toMatchObject({ group: 0, width: 80 })
+        expect(resized[1][0]).toMatchObject({ group: 2, depth: 20 })
+        expect(gridMatchesLayout(resized, 180, 120, 100, 100)).toBe(true)
+        expect(gridMatchesLayout(resized, 181, 120, 100, 100)).toBe(false)
+    })
+
+    it('falls back to one safe segment for invalid dimensions', () => {
+        const resized = resizeGrid(
+            [],
+            Number.NaN,
+            50,
+            0,
+            Number.POSITIVE_INFINITY
+        )
+
+        expect(resized).toHaveLength(1)
+        expect(resized[0]).toHaveLength(1)
+        expect(resized[0][0]).toMatchObject({
+            width: 1,
+            depth: 1,
+            group: 0,
+        })
+    })
+})
+
+describe('parameter validation', () => {
+    it('clamps invalid model parameters to finite safe values', () => {
+        const sanitized = sanitizeModelParameters({
+            totalWidth: Number.NaN,
+            totalDepth: -10,
+            maxBoxWidth: 0,
+            maxBoxDepth: Number.POSITIVE_INFINITY,
+            wallHeight: Number.NEGATIVE_INFINITY,
+            wallThickness: 999,
+            cornerRadius: 999,
+        })
+
+        expect(sanitized.totalWidth).toBe(150)
+        expect(sanitized.totalDepth).toBe(1)
+        expect(sanitized.maxBoxWidth).toBe(1)
+        expect(sanitized.maxBoxDepth).toBe(100)
+        expect(sanitized.wallHeight).toBe(30)
+        expect(Number.isFinite(sanitized.wallThickness)).toBe(true)
+        expect(Number.isFinite(sanitized.cornerRadius)).toBe(true)
+        expect(sanitized.wallThickness).toBeLessThanOrEqual(0.4)
+        expect(sanitized.cornerRadius).toBeLessThanOrEqual(0.5)
+    })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from 'node:path'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+    resolve: {
+        alias: {
+            '@': path.resolve(__dirname),
+        },
+    },
+    test: {
+        environment: 'node',
+        globals: true,
+    },
+})


### PR DESCRIPTION
## What changed
- Added Vitest coverage for outline ordering, rectangle boxes, L-shaped combined boxes, split boxes, visibility, resize behavior, invalid dimensions, empty grids, disconnected groups, and holed groups.
- Added explicit geometry guards for empty grids and unsupported multi-loop groups so failures are deliberate instead of accidental crashes or silent geometry loss.
- Added a combine policy helper and wired it into keyboard, action bar, and context menu combine flows so invalid disconnected/holed selections are rejected before mutating grid state or rebuilding Three.js geometry.
- Kept ESLint on the declared version and adjusted config handling so repo lint can run under the current dependency set.

## Why
TW-208 needs confidence that core geometry generation stays valid as model features change. The review also found that rejecting disconnected groups only in the geometry layer left the UI able to create invalid state, so combine validation now happens before mutation.

## Validation
- `npm test` passes: 18 tests
- `npx tsc --noEmit` passes
- `npm run lint` passes with existing hook warnings only
- `npx next build` passes
- `npx prettier --check app components lib tests vitest.config.ts eslint.config.mjs package.json` passes