### PR TITLE
Fix redraw selection and current-box picking

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,11 +4,22 @@ import ActionsBar from '@/components/ActionsBar'
 import BoxContextMenu from '@/components/BoxContextMenu'
 import HiddenBoxesDisplay from '@/components/HiddenBoxesDisplay'
 import { generateCustomBox } from '@/lib/boxHelper'
-import { cameraSettings, material } from '@/lib/defaults'
+import { cameraSettings } from '@/lib/defaults'
 import { combineGridBoxes, getNextAvailableGroupId } from '@/lib/gridCombine'
 import { gridMatchesLayout, resizeGrid } from '@/lib/gridHelper'
-import { isGridBoxVisible, setGridBoxVisible } from '@/lib/gridVisibility'
+import {
+    getBoxById,
+    getGridBoxes,
+    isGridBoxVisible,
+    setGridBoxVisible,
+} from '@/lib/gridVisibility'
+import {
+    applyRenderedBoxSelection,
+    renderRuntime,
+    setRenderedBoxGroup,
+} from '@/lib/renderRuntime'
 import { useStore } from '@/lib/store'
+import type { Grid, SelectionId } from '@/lib/types'
 import { useEffect } from 'react'
 import * as THREE from 'three'
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
@@ -17,7 +28,7 @@ export default function Home() {
     const state = useStore()
 
     useEffect(() => {
-        const container = state.containerRef.current
+        const container = renderRuntime.containerRef.current
         if (!container) return
 
         function initBasics(container: HTMLDivElement) {
@@ -48,13 +59,13 @@ export default function Home() {
         }
 
         const { scene, camera, renderer } = initBasics(container)
-        state.sceneRef.current = scene
-        state.cameraRef.current = camera
-        state.rendererRef.current = renderer
+        renderRuntime.sceneRef.current = scene
+        renderRuntime.cameraRef.current = camera
+        renderRuntime.rendererRef.current = renderer
 
         const controls = new OrbitControls(camera, renderer.domElement)
         controls.enableDamping = true
-        state.controlsRef.current = controls
+        renderRuntime.controlsRef.current = controls
         controls.mouseButtons = {
             LEFT: THREE.MOUSE.ROTATE,
             MIDDLE: THREE.MOUSE.PAN,
@@ -78,11 +89,15 @@ export default function Home() {
 
         // resize handler
         const onWindowResize = () => {
-            if (!state.cameraRef.current || !state.rendererRef.current) return
-            state.cameraRef.current.aspect =
+            if (
+                !renderRuntime.cameraRef.current ||
+                !renderRuntime.rendererRef.current
+            )
+                return
+            renderRuntime.cameraRef.current.aspect =
                 window.innerWidth / window.innerHeight
-            state.cameraRef.current.updateProjectionMatrix()
-            state.rendererRef.current.setSize(
+            renderRuntime.cameraRef.current.updateProjectionMatrix()
+            renderRuntime.rendererRef.current.setSize(
                 window.innerWidth,
                 window.innerHeight
             )
@@ -100,16 +115,13 @@ export default function Home() {
 
         const raycaster = new THREE.Raycaster()
         const mouse = new THREE.Vector2()
-        let selectedGroups: THREE.Group[] = []
-
         window.addEventListener('keydown', onKeyDown)
 
         function onKeyDown(event: KeyboardEvent) {
             const currentState = useStore.getState()
 
             if (event.key === 'Escape') {
-                selectedGroups = []
-                currentState.setSelectedGroups(selectedGroups)
+                currentState.setSelectedBoxIds([])
             }
             if (event.key === 'c') {
                 onCombineClick()
@@ -124,18 +136,23 @@ export default function Home() {
 
         function rebuildBoxFromCurrentState() {
             const currentState = useStore.getState()
-            const scene = currentState.sceneRef.current
-            const currentBox = currentState.boxRef.current
+            const scene = renderRuntime.sceneRef.current
+            const currentBox = renderRuntime.boxRef.current
             if (!scene || !currentBox) return
 
             removeAndDisposeObject(scene, currentBox)
             const newBox = generateCustomBox(
-                currentState.gridRef.current,
+                currentState.grid,
                 currentState.wallThickness,
                 currentState.cornerRadius,
                 currentState.generateBottom
             )
-            currentState.boxRef.current = newBox
+            setRenderedBoxGroup(
+                newBox,
+                currentState.selectedBoxIds,
+                currentState.standardColor,
+                currentState.selectedColor
+            )
             newBox.position.set(
                 -currentState.totalWidth / 2,
                 0,
@@ -146,58 +163,58 @@ export default function Home() {
 
         function onCombineClick() {
             const currentState = useStore.getState()
-            const groupsToCombine = currentState.selectedGroups
-            if (groupsToCombine.length < 2) return
-            const currentBox = currentState.boxRef.current
+            const boxesToCombine = getGridBoxes(
+                currentState.grid,
+                currentState.wallHeight
+            ).filter((box) => currentState.selectedBoxIds.includes(box.id))
+            if (boxesToCombine.length < 2) return
+            const currentBox = renderRuntime.boxRef.current
             if (!currentBox) return
 
-            const grid = currentState.gridRef.current
+            const grid = cloneGrid(currentState.grid)
             const newId = getNextAvailableGroupId(grid)
-            if (!combineGridBoxes(grid, groupsToCombine, newId)) return
+            if (!combineGridBoxes(grid, boxesToCombine, newId)) return
 
+            currentState.setGrid(grid)
             rebuildBoxFromCurrentState()
-
-            selectedGroups = []
-            currentState.setSelectedGroups(selectedGroups)
+            currentState.setSelectedBoxIds([])
         }
 
         function onSplitClick() {
             const currentState = useStore.getState()
-            const groupsToSplit = currentState.selectedGroups
-            if (groupsToSplit.length === 0) return
+            const boxesToSplit = currentState.selectedBoxIds
+                .map((id) => getBoxById(currentState.grid, id))
+                .filter((box) => box !== undefined)
+            if (boxesToSplit.length === 0) return
 
-            const grid = currentState.gridRef.current
-            groupsToSplit.forEach((grp) => {
-                const cells: { x: number; z: number }[] = grp.userData.cells
-                cells.forEach(({ x, z }) => {
+            const grid = cloneGrid(currentState.grid)
+            boxesToSplit.forEach((box) => {
+                box.cells.forEach(({ x, z }) => {
                     grid[z][x].group = 0
                 })
             })
 
+            currentState.setGrid(grid)
             rebuildBoxFromCurrentState()
-
-            selectedGroups = []
-            currentState.setSelectedGroups(selectedGroups)
+            currentState.setSelectedBoxIds([])
         }
 
         function onHideClick() {
             const currentState = useStore.getState()
-            const groupsToHide = currentState.selectedGroups
-            if (groupsToHide.length === 0) return
+            const boxesToHide = currentState.selectedBoxIds
+                .map((id) => getBoxById(currentState.grid, id))
+                .filter((box) => box !== undefined)
+            if (boxesToHide.length === 0) return
 
-            const grid = currentState.gridRef.current
+            const grid = cloneGrid(currentState.grid)
 
-            groupsToHide.forEach((grp) => {
-                const box = grp.userData as {
-                    cells: Array<{ x: number; z: number }>
-                }
+            boxesToHide.forEach((box) => {
                 setGridBoxVisible(grid, box, !isGridBoxVisible(grid, box))
             })
 
+            currentState.setGrid(grid)
             rebuildBoxFromCurrentState()
-
-            selectedGroups = []
-            currentState.setSelectedGroups(selectedGroups)
+            currentState.setSelectedBoxIds([])
         }
 
         function onPointerDown(event: MouseEvent) {
@@ -223,19 +240,20 @@ export default function Home() {
             })
             if (!hit) return
 
-            const box = (hit.object as THREE.Mesh).parent as THREE.Group
+            const boxId = (hit.object as THREE.Mesh).parent?.name as SelectionId
+            if (!renderRuntime.boxMeshes.has(boxId)) return
 
-            if (!isMultiSelect) {
-                selectedGroups = []
-            }
+            const selectedBoxIds = isMultiSelect
+                ? [...useStore.getState().selectedBoxIds]
+                : []
 
-            const i = selectedGroups.indexOf(box)
+            const i = selectedBoxIds.indexOf(boxId)
             if (i !== -1) {
-                selectedGroups.splice(i, 1)
+                selectedBoxIds.splice(i, 1)
             } else {
-                selectedGroups.push(box)
+                selectedBoxIds.push(boxId)
             }
-            useStore.getState().setSelectedGroups([...selectedGroups])
+            useStore.getState().setSelectedBoxIds(selectedBoxIds)
         }
 
         renderer.domElement.addEventListener('pointerdown', onPointerDown)
@@ -254,105 +272,116 @@ export default function Home() {
             renderer.dispose()
             renderer.forceContextLoss()
             renderer.domElement.remove()
-            state.sceneRef.current = null
-            state.cameraRef.current = null
-            state.rendererRef.current = null
-            state.controlsRef.current = null
-            state.boxRef.current = null
-            state.helperGridRef.current = null
+            renderRuntime.sceneRef.current = null
+            renderRuntime.cameraRef.current = null
+            renderRuntime.rendererRef.current = null
+            renderRuntime.controlsRef.current = null
+            renderRuntime.boxRef.current = null
+            renderRuntime.helperGridRef.current = null
+            renderRuntime.boxMeshes.clear()
         }
     }, [])
 
     useEffect(() => {
-        const boxGroup = state.boxRef.current
-        if (!boxGroup) return
-
-        // clear
-        boxGroup.children.forEach((child) => {
-            if (!(child instanceof THREE.Group)) return
-            child.traverse((c) => {
-                if (c instanceof THREE.Mesh)
-                    c.material.color.setHex(material.standard.color)
-            })
-        })
-
-        // highlight selected
-        state.selectedGroups.forEach((grp) =>
-            grp.traverse((c) => {
-                if (c instanceof THREE.Mesh)
-                    c.material.color.setHex(material.selected.color)
-            })
+        applyRenderedBoxSelection(
+            state.selectedBoxIds,
+            state.standardColor,
+            state.selectedColor
         )
-    }, [state.selectedGroups])
+    }, [state.selectedBoxIds, state.standardColor, state.selectedColor])
+
+    const {
+        grid: modelGrid,
+        totalWidth,
+        totalDepth,
+        maxBoxWidth,
+        maxBoxDepth,
+        wallThickness,
+        cornerRadius,
+        generateBottom,
+        wallHeight,
+        redrawTrigger,
+        showCornerLines,
+        setGrid,
+    } = state
 
     useEffect(() => {
-        const scene = state.sceneRef.current
+        const scene = renderRuntime.sceneRef.current
         if (!scene) return
 
-        if (state.boxRef.current) {
-            removeAndDisposeObject(scene, state.boxRef.current)
-            state.boxRef.current = null
+        if (renderRuntime.boxRef.current) {
+            removeAndDisposeObject(scene, renderRuntime.boxRef.current)
+            renderRuntime.boxRef.current = null
         }
 
-        const old = state.gridRef.current
+        const old = modelGrid
+        let grid = old
         if (
             !gridMatchesLayout(
                 old,
-                state.totalWidth,
-                state.totalDepth,
-                state.maxBoxWidth,
-                state.maxBoxDepth
+                totalWidth,
+                totalDepth,
+                maxBoxWidth,
+                maxBoxDepth
             )
         ) {
-            state.gridRef.current = resizeGrid(
+            grid = resizeGrid(
                 old,
-                state.totalWidth,
-                state.totalDepth,
-                state.maxBoxWidth,
-                state.maxBoxDepth
+                totalWidth,
+                totalDepth,
+                maxBoxWidth,
+                maxBoxDepth
             )
+            setGrid(grid)
         }
 
-        const grid = state.gridRef.current
         const box = generateCustomBox(
             grid,
-            state.wallThickness,
-            state.cornerRadius,
-            state.generateBottom
+            wallThickness,
+            cornerRadius,
+            generateBottom
         )
-        state.boxRef.current = box
-        box.position.set(-state.totalWidth / 2, 0, -state.totalDepth / 2)
+        const currentState = useStore.getState()
+        setRenderedBoxGroup(
+            box,
+            currentState.selectedBoxIds,
+            currentState.standardColor,
+            currentState.selectedColor
+        )
+        box.position.set(-totalWidth / 2, 0, -totalDepth / 2)
         scene.add(box)
     }, [
-        state.wallThickness,
-        state.cornerRadius,
-        state.wallHeight,
-        state.generateBottom,
-        state.totalWidth,
-        state.totalDepth,
-        state.maxBoxWidth,
-        state.maxBoxDepth,
-        state.redrawTrigger,
-        state.showCornerLines,
+        wallThickness,
+        cornerRadius,
+        wallHeight,
+        generateBottom,
+        totalWidth,
+        totalDepth,
+        maxBoxWidth,
+        maxBoxDepth,
+        modelGrid,
+        redrawTrigger,
+        showCornerLines,
+        setGrid,
     ])
 
     useEffect(() => {
-        const scene = state.sceneRef.current
+        const scene = renderRuntime.sceneRef.current
         if (!scene) return
 
         const size = Math.max(state.totalWidth, state.totalDepth) + 50
         const divisions = Math.ceil(size / 10)
 
-        if (state.helperGridRef.current) {
-            removeAndDisposeObject(scene, state.helperGridRef.current)
+        if (renderRuntime.helperGridRef.current) {
+            removeAndDisposeObject(scene, renderRuntime.helperGridRef.current)
         }
 
         if (state.showHelperGrid) {
             const grid = new THREE.GridHelper(size, divisions)
-            state.helperGridRef.current = grid
+            renderRuntime.helperGridRef.current = grid
             scene.add(grid)
         } else {
-            state.helperGridRef.current = null
+            renderRuntime.helperGridRef.current = null
         }
     }, [state.totalWidth, state.totalDepth, state.showHelperGrid])
 
@@ -362,10 +391,10 @@ export default function Home() {
                 <div className="h-full">
                     <div className="h-full flex flex-col lg:block">
                         <div
-                            ref={state.containerRef}
+                            ref={renderRuntime.containerRef}
                             className="relative h-full w-full"
                         >
-                            {state.containerRef.current && <BoxContextMenu />}
+                            <BoxContextMenu />
                             <HiddenBoxesDisplay />
                         </div>
                         <ActionsBar />
@@ -374,6 +403,10 @@ export default function Home() {
             </div>
         </div>
     )
+}
+
+function cloneGrid(grid: Grid): Grid {
+    return grid.map((row) => row.map((cell) => ({ ...cell })))
 }
 
 function removeAndDisposeObject(

--- a/components/ActionsBar.tsx
+++ b/components/ActionsBar.tsx
@@ -17,7 +17,9 @@ import {
 } from '@/components/ui/tooltip'
 import { cameraSettings } from '@/lib/defaults'
 import { canCombineGridBoxes } from '@/lib/gridCombine'
+import { getGridBoxes } from '@/lib/gridVisibility'
 import { keyPress } from '@/lib/keyHelper'
+import { renderRuntime } from '@/lib/renderRuntime'
 import { useStore } from '@/lib/store'
 import {
     Box,
@@ -28,13 +30,12 @@ import {
     SquareSplitHorizontal,
     X,
 } from 'lucide-react'
-import { useEffect, useState } from 'react'
 
 export default function ActionsBar() {
     const store = useStore()
     const position = store.actionsBarPosition || 'bottom'
-    const camera = store.cameraRef
-    const controls = store.controlsRef
+    const camera = renderRuntime.cameraRef
+    const controls = renderRuntime.controlsRef
     const initialPosition = React.useRef(
         new THREE.Vector3(
             cameraSettings.position.x,
@@ -42,12 +43,14 @@ export default function ActionsBar() {
             cameraSettings.position.z
         )
     )
-    const [enableClearSelection, setEnableClearSelection] = useState(false)
-    const [canSplit, setCanSplit] = useState(false)
-
+    const selectedBoxes = getGridBoxes(store.grid, store.wallHeight).filter(
+        (box) => store.selectedBoxIds.includes(box.id)
+    )
+    const enableClearSelection = selectedBoxes.length > 0
+    const canSplit = selectedBoxes.length === 1 && selectedBoxes[0].group !== 0
     const canCombine =
-        store.selectedGroups.length >= 2 &&
-        canCombineGridBoxes(store.gridRef.current, store.selectedGroups)
+        selectedBoxes.length >= 2 &&
+        canCombineGridBoxes(store.grid, selectedBoxes)
     const canUseBoxAction = canSplit || canCombine
 
     const resetCamera = () => {
@@ -69,24 +72,6 @@ export default function ActionsBar() {
         controls.current.target.set(0, 0, 0)
         controls.current.update()
     }
-
-    useEffect(() => {
-        if (store.selectedGroups.length > 0) {
-            setEnableClearSelection(true)
-            if (store.selectedGroups.length == 1) {
-                if (store.selectedGroups[0].userData.group != 0) {
-                    setCanSplit(true)
-                } else {
-                    setCanSplit(false)
-                }
-            } else {
-                setCanSplit(false)
-            }
-        } else {
-            setEnableClearSelection(false)
-            setCanSplit(false)
-        }
-    }, [store.selectedGroups])
 
     return (
         <div className="lg:bottom-18 lg:ml-auto lg:-right-6 z-10 transform relative lg:w-fit">
@@ -140,7 +125,7 @@ export default function ActionsBar() {
                                     ? ' cursor-pointer'
                                     : ' cursor-not-allowed text-neutral-400')
                             }
-                            onClick={() => store.setSelectedGroups([])}
+                            onClick={() => store.setSelectedBoxIds([])}
                             disabled={!enableClearSelection}
                         >
                             <X className="h-4 w-4" />

--- a/components/BoxContextMenu.tsx
+++ b/components/BoxContextMenu.tsx
@@ -1,9 +1,12 @@
 'use client'
 
+import { pickCurrentBox } from '@/lib/boxPicking'
 import { canCombineGridBoxes } from '@/lib/gridCombine'
+import { getBoxById, getGridBoxes } from '@/lib/gridVisibility'
 import { keyPress } from '@/lib/keyHelper'
+import { renderRuntime } from '@/lib/renderRuntime'
 import { useStore } from '@/lib/store'
-import { BoxInfo } from '@/lib/types'
+import type { GeneratedBoxMetadata } from '@/lib/types'
 import {
     Boxes,
     Combine,
@@ -24,26 +27,19 @@ declare global {
 export default function BoxContextMenu() {
     const [open, setOpen] = useState(false)
     const [pos, setPos] = useState({ x: 0, y: 0 })
-    const [boxInfos, setBoxInfos] = useState<BoxInfo | null>(null)
+    const [boxInfos, setBoxInfos] = useState<GeneratedBoxMetadata | null>(null)
     const menuRef = useRef<HTMLDivElement>(null)
 
-    const storeContainerRef = useStore((state) => state.containerRef)
-    const cameraRef = useStore((state) => state.cameraRef)
-    const boxRef = useStore((state) => state.boxRef)
-    const gridRef = useStore((state) => state.gridRef)
-    const setSelectedGroups = useStore((state) => state.setSelectedGroups)
-    const selectedGroups = useStore((state) => state.selectedGroups)
+    const grid = useStore((state) => state.grid)
+    const wallHeight = useStore((state) => state.wallHeight)
+    const setSelectedBoxIds = useStore((state) => state.setSelectedBoxIds)
+    const selectedBoxIds = useStore((state) => state.selectedBoxIds)
 
     const [canSplit, setCanSplit] = useState(false)
 
     useEffect(() => {
-        const container = storeContainerRef.current
-        const cam = cameraRef.current
-        const grp = boxRef.current
-
-        if (!container || !cam || !grp) {
-            return
-        }
+        const container = renderRuntime.containerRef.current
+        if (!container) return
 
         const raycaster = new THREE.Raycaster()
         const mouse = new THREE.Vector2()
@@ -55,20 +51,20 @@ export default function BoxContextMenu() {
                 return
             }
 
-            if (!container) return
             const rect = container.getBoundingClientRect()
             mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1
             mouse.y = -((e.clientY - rect.top) / rect.height) * 2 + 1
 
-            raycaster.setFromCamera(mouse, cam)
-            const hits = raycaster.intersectObjects(grp.children, true)
-            const hit = hits.find((h) => {
-                const p = h.object.parent as THREE.Group
-                return typeof p.userData.group === 'number'
-            })
+            const boxId = pickCurrentBox(raycaster, mouse)
 
-            if (hit?.object.parent) {
-                setBoxInfos(hit.object.parent.userData as BoxInfo)
+            if (boxId) {
+                setBoxInfos(
+                    getBoxById(
+                        useStore.getState().grid,
+                        boxId,
+                        useStore.getState().wallHeight
+                    ) ?? null
+                )
             } else {
                 setBoxInfos(null)
             }
@@ -83,7 +79,7 @@ export default function BoxContextMenu() {
                 container.removeEventListener('contextmenu', onContextMenu)
             }
         }
-    }, [storeContainerRef, cameraRef, boxRef])
+    }, [])
 
     useEffect(() => {
         if (!open) {
@@ -118,8 +114,11 @@ export default function BoxContextMenu() {
     }, [open])
 
     useEffect(() => {
-        if (selectedGroups.length === 1) {
-            if (selectedGroups[0].userData.group !== 0) {
+        const selectedBoxes = getGridBoxes(grid, wallHeight).filter((box) =>
+            selectedBoxIds.includes(box.id)
+        )
+        if (selectedBoxes.length === 1) {
+            if (selectedBoxes[0].group !== 0) {
                 setCanSplit(true)
             } else {
                 setCanSplit(false)
@@ -127,7 +126,7 @@ export default function BoxContextMenu() {
         } else {
             setCanSplit(false)
         }
-    }, [selectedGroups])
+    }, [selectedBoxIds, grid, wallHeight])
 
     const handleMenuItemClick = (
         action?:
@@ -144,24 +143,13 @@ export default function BoxContextMenu() {
         }
 
         if (action === 'Select Box') {
-            // Find the box group that matches the boxInfos using the unique ID
-            const boxGroup = boxRef.current?.children.find(
-                (child) => child.userData.id === boxInfos?.id
-            ) as THREE.Group | undefined
-
-            if (boxGroup) {
-                setSelectedGroups([boxGroup])
+            if (boxInfos) {
+                setSelectedBoxIds([boxInfos.id])
             }
         } else if (action === 'Add to Selection') {
-            // Find the box group that matches the boxInfos using the unique ID
-            const boxGroup = boxRef.current?.children.find(
-                (child) => child.userData.id === boxInfos?.id
-            ) as THREE.Group | undefined
-
-            if (boxGroup) {
-                // Add to existing selection if not already selected
-                if (!selectedGroups.includes(boxGroup)) {
-                    setSelectedGroups([...selectedGroups, boxGroup])
+            if (boxInfos) {
+                if (!selectedBoxIds.includes(boxInfos.id)) {
+                    setSelectedBoxIds([...selectedBoxIds, boxInfos.id])
                 }
             }
         } else if (action === 'Split Box') {
@@ -169,13 +157,13 @@ export default function BoxContextMenu() {
                 keyPress('s')
             }
         } else if (action === 'Combine Selected Boxes') {
-            if (selectedGroups.length >= 2) {
+            if (selectedBoxIds.length >= 2) {
                 keyPress('c')
             }
         } else if (action === 'Toggle Visibility') {
             keyPress('h')
         } else if (action === 'Clear Selection') {
-            setSelectedGroups([])
+            setSelectedBoxIds([])
         }
 
         setOpen(false)
@@ -185,15 +173,18 @@ export default function BoxContextMenu() {
 
     const isBoxSpecificMenu = boxInfos != null
 
-    const isBoxSelected =
-        boxInfos &&
-        selectedGroups.some((group) => group.userData.id === boxInfos.id)
+    const isBoxSelected = boxInfos && selectedBoxIds.includes(boxInfos.id)
 
     const canCombine =
-        selectedGroups.length >= 2 &&
-        canCombineGridBoxes(gridRef.current, selectedGroups)
+        selectedBoxIds.length >= 2 &&
+        canCombineGridBoxes(
+            grid,
+            getGridBoxes(grid, wallHeight).filter((box) =>
+                selectedBoxIds.includes(box.id)
+            )
+        )
 
-    if (selectedGroups.length === 0) {
+    if (selectedBoxIds.length === 0) {
         // if no boxes are selected, don't show the menu
         return null
     }
@@ -224,7 +215,7 @@ export default function BoxContextMenu() {
                         </div>
                     )}
                     <div className="px-2 py-1.5 text-sm font-semibold">
-                        Box {boxInfos.id}
+                        Box {boxInfos.index}
                         {boxInfos.group != 0
                             ? `(| Group ${boxInfos.group})`
                             : ''}

--- a/components/HiddenBoxesDisplay.tsx
+++ b/components/HiddenBoxesDisplay.tsx
@@ -12,21 +12,23 @@ import { useCallback, useState } from 'react'
 export default function HiddenBoxesDisplay() {
     const store = useStore()
     const [isCollapsed, setIsCollapsed] = useState(false)
-    const hiddenBoxes = getGridBoxes(store.gridRef.current).filter(
-        (box) => !box.visible
+    const hiddenBoxes = getGridBoxes(store.grid, store.wallHeight).filter(
+        (box) => box.visibility === 'hidden'
     )
 
     const handleUnhideBox = (boxToUnhide: GridBoxInfo) => {
-        setGridBoxVisible(store.gridRef.current, boxToUnhide, true)
-        store.forceRedraw()
+        const grid = store.grid.map((row) => row.map((cell) => ({ ...cell })))
+        setGridBoxVisible(grid, boxToUnhide, true)
+        store.setGrid(grid)
     }
 
     const handleUnhideAll = useCallback(() => {
-        getGridBoxes(store.gridRef.current).forEach((box) => {
-            setGridBoxVisible(store.gridRef.current, box, true)
+        const grid = store.grid.map((row) => row.map((cell) => ({ ...cell })))
+        getGridBoxes(grid).forEach((box) => {
+            setGridBoxVisible(grid, box, true)
         })
-        store.setSelectedGroups([])
-        store.forceRedraw()
+        store.setGrid(grid)
+        store.setSelectedBoxIds([])
     }, [store])
 
     if (hiddenBoxes.length === 0) {
@@ -61,7 +63,7 @@ export default function HiddenBoxesDisplay() {
                             title="Unhide Box"
                         >
                             <span>
-                                Box {box.id}
+                                Box {box.index}
                                 {box.group !== 0 ? ` (Group ${box.group})` : ''}
                             </span>
                             <button

--- a/lib/boxHelper.ts
+++ b/lib/boxHelper.ts
@@ -23,8 +23,6 @@ export function generateCustomBox(
         (i) => i > 0
     )
 
-    let nextBoxId = 1
-
     const widths = grid[0].map((c) => c.width)
     const depths = grid.map((row) => row[0].depth)
     const cumW: number[] = [0]
@@ -39,7 +37,7 @@ export function generateCustomBox(
             for (let x = 0; x < grid[0].length; x++) {
                 if (grid[z][x].group === id) {
                     cellsForThisId.push({ x, z })
-                    if (grid[z][x].visible !== false) {
+                    if (grid[z][x].visibility !== 'hidden') {
                         // If cell is not explicitly hidden, it's visible
                         isBoxVisible = true
                     }
@@ -77,16 +75,8 @@ export function generateCustomBox(
         const depth = cumD[maxZ + 1] - cumD[minZ]
 
         const boxGroup = new THREE.Group()
-        boxGroup.userData.group = id
-        boxGroup.userData.id = nextBoxId++
-        boxGroup.userData.cells = cellsForThisId
-        boxGroup.userData.dimensions = {
-            width,
-            depth,
-            height: useStore.getState().wallHeight,
-        }
+        boxGroup.name = `group:${id}`
         boxGroup.visible = isBoxVisible
-        boxGroup.userData.visible = isBoxVisible
 
         boxGroup.add(buildWallMesh(outR, inR))
         if (generate_bottom) boxGroup.add(buildBottomMesh(outR, wall_thickness))
@@ -111,7 +101,14 @@ export function generateCustomBox(
             if (cell.group !== 0) continue
 
             const singleGrid: Cell[][] = [
-                [{ group: 0, width: cell.width, depth: cell.depth }],
+                [
+                    {
+                        group: 0,
+                        width: cell.width,
+                        depth: cell.depth,
+                        visibility: 'visible',
+                    },
+                ],
             ]
             const rawO = getOutline(singleGrid, 0)
             const rawI = offsetPolygonCCW(rawO, wall_thickness)
@@ -141,18 +138,8 @@ export function generateCustomBox(
             })
 
             const cellGroup = new THREE.Group()
-            cellGroup.userData.selectable = true
-            cellGroup.userData.group = 0
-            cellGroup.userData.id = nextBoxId++
-            cellGroup.userData.cells = [{ x, z }]
-            cellGroup.visible = cell.visible !== false
-            cellGroup.userData.visible = cell.visible !== false
-
-            cellGroup.userData.dimensions = {
-                width: cell.width,
-                depth: cell.depth,
-                height: useStore.getState().wallHeight,
-            }
+            cellGroup.name = `cell:${x}:${z}`
+            cellGroup.visible = cell.visibility !== 'hidden'
             cellGroup.add(buildWallMesh(outR, inR))
             if (generate_bottom)
                 cellGroup.add(buildBottomMesh(outR, wall_thickness))
@@ -231,6 +218,6 @@ function createCornerLines(
     })
 
     const lines = new THREE.LineSegments(geometry, material)
-    lines.userData.isCornerLine = true
+    lines.name = 'corner-lines'
     return lines
 }

--- a/lib/boxPicking.ts
+++ b/lib/boxPicking.ts
@@ -1,0 +1,25 @@
+import { renderRuntime } from '@/lib/renderRuntime'
+import type { SelectionId } from '@/lib/types'
+import * as THREE from 'three'
+
+export function pickCurrentBox(
+    raycaster: THREE.Raycaster,
+    pointer: THREE.Vector2
+): SelectionId | null {
+    const camera = renderRuntime.cameraRef.current
+    const boxGroup = renderRuntime.boxRef.current
+    if (!camera || !boxGroup) return null
+
+    raycaster.setFromCamera(pointer, camera)
+    const hit = raycaster
+        .intersectObjects(boxGroup.children, true)
+        .find(({ object }) => {
+            const parent = object.parent
+            return (
+                parent instanceof THREE.Group &&
+                renderRuntime.boxMeshes.has(parent.name as SelectionId)
+            )
+        })
+
+    return (hit?.object.parent?.name as SelectionId | undefined) ?? null
+}

--- a/lib/exportUtils.ts
+++ b/lib/exportUtils.ts
@@ -1,5 +1,6 @@
 import { generateCustomBox } from '@/lib/boxHelper'
 import { getGridBoxes } from '@/lib/gridVisibility'
+import { renderRuntime } from '@/lib/renderRuntime'
 import { useStore } from '@/lib/store'
 import * as THREE from 'three'
 import { STLExporter } from 'three/examples/jsm/exporters/STLExporter.js'
@@ -9,7 +10,7 @@ import { STLExporter } from 'three/examples/jsm/exporters/STLExporter.js'
  */
 export function handleStlExport(): void {
     const state = useStore.getState()
-    const grid = state.gridRef.current
+    const grid = state.grid
     if (grid.length === 0) return
 
     // Wrap & rotate so Three's Y-up becomes STL Z-up
@@ -50,13 +51,13 @@ export function handleStlExport(): void {
  */
 export async function handleExportMultipleSTLs(): Promise<void> {
     const state = useStore.getState()
-    const boxGroup = state.boxRef.current
-    const grid = state.gridRef.current
+    const boxGroup = renderRuntime.boxRef.current
+    const grid = state.grid
     if (!boxGroup || grid.length === 0) return
 
     const boxWidths = grid[0].map((cell) => cell.width)
     const boxDepths = grid.map((row) => row[0].depth)
-    const gridBoxes = getGridBoxes(grid)
+    const gridBoxes = getGridBoxes(grid, state.wallHeight)
 
     // group boxes by dimensions (ignoring width↔depth swap)
     type GroupInfo = {
@@ -69,19 +70,14 @@ export async function handleExportMultipleSTLs(): Promise<void> {
     }
     const groups = new Map<string, GroupInfo>()
 
-    boxGroup.children.forEach((box, idx) => {
-        if (gridBoxes[idx]?.visible === false) return
+    boxGroup.children.forEach((box) => {
+        const metadata = gridBoxes.find((entry) => entry.id === box.name)
+        if (!metadata || metadata.visibility === 'hidden') return
 
-        const ud = (box.userData.dimensions || {}) as {
-            width?: number
-            depth?: number
-            height?: number
-            isCombined?: boolean
-        }
-        const rawW = ud.width ?? boxWidths[idx % boxWidths.length]
-        const rawD = ud.depth ?? boxDepths[Math.floor(idx / boxWidths.length)]
-        const h = ud.height ?? state.wallHeight
-        const isCombined = ud.isCombined ?? false
+        const rawW = metadata.dimensions.width
+        const rawD = metadata.dimensions.depth
+        const h = metadata.dimensions.height
+        const isCombined = metadata.isCombined
         const [w, d] = [rawW, rawD].sort((a, b) => a - b)
         const prefix = isCombined ? 'combined_box' : 'box'
         const key = `${prefix}_${w.toFixed(2)}_${d.toFixed(2)}_${h.toFixed(2)}`

--- a/lib/gridCombine.ts
+++ b/lib/gridCombine.ts
@@ -1,12 +1,7 @@
 import { getOutline } from '@/lib/lineHelper'
-import { Grid } from '@/lib/types'
+import type { GeneratedBoxMetadata, Grid } from '@/lib/types'
 
-export type GridBoxSelection = {
-    cells?: Array<{ x: number; z: number }>
-    userData?: {
-        cells?: Array<{ x: number; z: number }>
-    }
-}
+export type GridBoxSelection = Pick<GeneratedBoxMetadata, 'cells'>
 
 export function canCombineGridBoxes(
     grid: Grid,
@@ -68,5 +63,5 @@ function selectedCellKeys(boxes: GridBoxSelection[]): Set<string> {
 function getSelectionCells(
     box: GridBoxSelection
 ): Array<{ x: number; z: number }> {
-    return box.cells ?? box.userData?.cells ?? []
+    return box.cells
 }

--- a/lib/gridHelper.ts
+++ b/lib/gridHelper.ts
@@ -17,7 +17,7 @@ export function resizeGrid(
             const oldCell = hasOld ? oldGrid[rowIdx][colIdx] : undefined
             return {
                 group: oldCell?.group ?? 0,
-                visible: oldCell?.visible,
+                visibility: oldCell?.visibility ?? 'visible',
                 width,
                 depth,
             }

--- a/lib/gridVisibility.ts
+++ b/lib/gridVisibility.ts
@@ -1,13 +1,13 @@
-import { Grid } from '@/lib/types'
+import type {
+    GeneratedBoxMetadata,
+    Grid,
+    GridCoordinate,
+    SelectionId,
+} from '@/lib/types'
 
-export type GridBoxInfo = {
-    id: number
-    group: number
-    cells: Array<{ x: number; z: number }>
-    visible: boolean
-}
+export type GridBoxInfo = GeneratedBoxMetadata
 
-export function getGridBoxes(grid: Grid): GridBoxInfo[] {
+export function getGridBoxes(grid: Grid, height = 0): GridBoxInfo[] {
     if (grid.length === 0) return []
 
     let nextBoxId = 1
@@ -19,10 +19,17 @@ export function getGridBoxes(grid: Grid): GridBoxInfo[] {
     groupIds.forEach((group) => {
         const cells = getCellsForGroup(grid, group)
         boxes.push({
-            id: nextBoxId++,
+            id: `group:${group}`,
+            index: nextBoxId++,
             group,
             cells,
-            visible: cells.some(({ x, z }) => grid[z][x].visible !== false),
+            dimensions: getDimensions(grid, cells, height),
+            visibility: cells.some(
+                ({ x, z }) => grid[z][x].visibility !== 'hidden'
+            )
+                ? 'visible'
+                : 'hidden',
+            isCombined: true,
         })
     })
 
@@ -32,10 +39,17 @@ export function getGridBoxes(grid: Grid): GridBoxInfo[] {
             if (cell.group !== 0) continue
 
             boxes.push({
-                id: nextBoxId++,
+                id: `cell:${x}:${z}`,
+                index: nextBoxId++,
                 group: 0,
                 cells: [{ x, z }],
-                visible: cell.visible !== false,
+                dimensions: {
+                    width: cell.width,
+                    depth: cell.depth,
+                    height,
+                },
+                visibility: cell.visibility ?? 'visible',
+                isCombined: false,
             })
         }
     }
@@ -49,7 +63,7 @@ export function setGridBoxVisible(
     visible: boolean
 ): void {
     box.cells.forEach(({ x, z }) => {
-        grid[z][x].visible = visible
+        grid[z][x].visibility = visible ? 'visible' : 'hidden'
     })
 }
 
@@ -57,14 +71,11 @@ export function isGridBoxVisible(
     grid: Grid,
     box: Pick<GridBoxInfo, 'cells'>
 ): boolean {
-    return box.cells.some(({ x, z }) => grid[z][x].visible !== false)
+    return box.cells.some(({ x, z }) => grid[z][x].visibility !== 'hidden')
 }
 
-function getCellsForGroup(
-    grid: Grid,
-    group: number
-): Array<{ x: number; z: number }> {
-    const cells: Array<{ x: number; z: number }> = []
+function getCellsForGroup(grid: Grid, group: number): GridCoordinate[] {
+    const cells: GridCoordinate[] = []
 
     for (let z = 0; z < grid.length; z++) {
         for (let x = 0; x < grid[0].length; x++) {
@@ -75,4 +86,22 @@ function getCellsForGroup(
     }
 
     return cells
+}
+
+export function getBoxById(
+    grid: Grid,
+    id: SelectionId,
+    height = 0
+): GridBoxInfo | undefined {
+    return getGridBoxes(grid, height).find((box) => box.id === id)
+}
+
+function getDimensions(grid: Grid, cells: GridCoordinate[], height: number) {
+    const xIndexes = new Set(cells.map(({ x }) => x))
+    const zIndexes = new Set(cells.map(({ z }) => z))
+    return {
+        width: [...xIndexes].reduce((sum, x) => sum + grid[0][x].width, 0),
+        depth: [...zIndexes].reduce((sum, z) => sum + grid[z][0].depth, 0),
+        height,
+    }
 }

--- a/lib/renderRuntime.ts
+++ b/lib/renderRuntime.ts
@@ -1,0 +1,63 @@
+import type { SelectionId } from '@/lib/types'
+import * as THREE from 'three'
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
+
+/**
+ * Imperative renderer state for the route's single canvas instance. This
+ * deliberately lives outside the app model and must not be shared by multiple
+ * simultaneous renderers.
+ */
+export const renderRuntime = {
+    containerRef: { current: null as HTMLDivElement | null },
+    sceneRef: { current: null as THREE.Scene | null },
+    cameraRef: { current: null as THREE.PerspectiveCamera | null },
+    rendererRef: { current: null as THREE.WebGLRenderer | null },
+    controlsRef: { current: null as OrbitControls | null },
+    boxRef: { current: null as THREE.Group | null },
+    helperGridRef: { current: null as THREE.GridHelper | null },
+    boxMeshes: new Map<SelectionId, THREE.Group>(),
+}
+
+export function setRenderedBoxGroup(
+    group: THREE.Group,
+    selectedIds: SelectionId[],
+    standardColor: number,
+    selectedColor: number
+): void {
+    renderRuntime.boxRef.current = group
+    renderRuntime.boxMeshes.clear()
+    group.children.forEach((child) => {
+        if (child instanceof THREE.Group) {
+            renderRuntime.boxMeshes.set(child.name as SelectionId, child)
+        }
+    })
+    applyRenderedBoxSelection(selectedIds, standardColor, selectedColor)
+}
+
+export function applyRenderedBoxSelection(
+    selectedIds: SelectionId[],
+    standardColor: number,
+    selectedColor: number
+): void {
+    renderRuntime.boxMeshes.forEach((group) => {
+        setMeshColor(group, standardColor)
+    })
+    selectedIds.forEach((id) => {
+        const group = renderRuntime.boxMeshes.get(id)
+        if (group) setMeshColor(group, selectedColor)
+    })
+}
+
+function setMeshColor(group: THREE.Group, color: number): void {
+    group.traverse((child) => {
+        if (!(child instanceof THREE.Mesh)) return
+        const materials = Array.isArray(child.material)
+            ? child.material
+            : [child.material]
+        materials.forEach((material) => {
+            if ('color' in material && material.color instanceof THREE.Color) {
+                material.color.setHex(color)
+            }
+        })
+    })
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,9 +1,7 @@
 import { cornerLine, material, parameters } from '@/lib/defaults'
 import type { ModelParameters } from '@/lib/parameterValidation'
 import { sanitizeModelParameters } from '@/lib/parameterValidation'
-import { Grid, StoreState } from '@/lib/types'
-import * as THREE from 'three'
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
+import { StoreState } from '@/lib/types'
 import { create } from 'zustand'
 
 export const useStore = create<StoreState>((set, get) => ({
@@ -32,21 +30,11 @@ export const useStore = create<StoreState>((set, get) => ({
     setMaxBoxDepth: (depth: number) =>
         setModelParameter(set, get, 'maxBoxDepth', depth),
 
-    // Refs
-    containerRef: { current: null as HTMLDivElement | null },
-    sceneRef: { current: null as THREE.Scene | null },
-    cameraRef: { current: null as THREE.PerspectiveCamera | null },
-    rendererRef: { current: null as THREE.WebGLRenderer | null },
-    controlsRef: { current: null as OrbitControls | null },
-    boxRef: { current: null as THREE.Group | null },
-    gridRef: {
-        current: [] as Grid,
-    },
-    helperGridRef: { current: null as THREE.GridHelper | null },
+    grid: [],
+    setGrid: (grid) => set({ grid }),
 
-    // Helpers
-    selectedGroups: [] as THREE.Group[],
-    setSelectedGroups: (groups) => set({ selectedGroups: groups }),
+    selectedBoxIds: [],
+    setSelectedBoxIds: (selectedBoxIds) => set({ selectedBoxIds }),
     // General
     showHelperGrid: true,
     setShowHelperGrid: (show: boolean) => set({ showHelperGrid: show }),

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,18 +1,46 @@
-import * as THREE from 'three'
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
+export type Visibility = 'visible' | 'hidden'
 
-export type Cell = {
+export type GridCell = {
     group: number
     width: number
     depth: number
+    visibility?: Visibility
     color?: number
-    visible?: boolean
 }
 
-export type Grid = Cell[][]
+/** @deprecated Use GridCell. */
+export type Cell = GridCell
 
-export interface StoreState {
-    // Parameters
+export type Grid = GridCell[][]
+
+export type GridCoordinate = {
+    x: number
+    z: number
+}
+
+export type SelectionId = `group:${number}` | `cell:${number}:${number}`
+
+export type BoxDimensions = {
+    width: number
+    depth: number
+    height: number
+}
+
+export type Box = {
+    id: SelectionId
+    index: number
+    group: number
+    cells: GridCoordinate[]
+    visibility: Visibility
+}
+
+/** Pure metadata produced from a grid before any Three.js objects are built. */
+export type GeneratedBoxMetadata = Box & {
+    dimensions: BoxDimensions
+    isCombined: boolean
+}
+
+export type ModelConfig = {
     totalWidth: number
     totalDepth: number
     wallThickness: number
@@ -21,6 +49,20 @@ export interface StoreState {
     generateBottom: boolean
     maxBoxWidth: number
     maxBoxDepth: number
+}
+
+export type DrawerInsert = {
+    config: ModelConfig
+    grid: Grid
+    selectedBoxIds: SelectionId[]
+}
+
+export interface StoreState extends ModelConfig {
+    grid: Grid
+    setGrid: (grid: Grid) => void
+
+    selectedBoxIds: SelectionId[]
+    setSelectedBoxIds: (ids: SelectionId[]) => void
 
     setTotalWidth: (width: number) => number
     setTotalDepth: (depth: number) => number
@@ -31,21 +73,6 @@ export interface StoreState {
     setMaxBoxWidth: (width: number) => number
     setMaxBoxDepth: (depth: number) => number
 
-    // Refs
-    containerRef: { current: HTMLDivElement | null }
-    sceneRef: { current: THREE.Scene | null }
-    cameraRef: { current: THREE.PerspectiveCamera | null }
-    rendererRef: { current: THREE.WebGLRenderer | null }
-    controlsRef: { current: OrbitControls | null }
-    boxRef: { current: THREE.Group | null }
-    gridRef: { current: Grid }
-    helperGridRef: { current: THREE.GridHelper | null }
-
-    // Helpers
-    selectedGroups: THREE.Group[]
-    setSelectedGroups: (groups: THREE.Group[]) => void
-
-    // General
     actionsBarPosition: 'top' | 'bottom'
     setActionsBarPosition: (position: 'top' | 'bottom') => void
 
@@ -60,7 +87,6 @@ export interface StoreState {
     redrawTrigger: number
     forceRedraw: () => void
 
-    // Corner Lines
     showCornerLines: boolean
     cornerLineColor: number
     cornerLineOpacity: number
@@ -68,18 +94,6 @@ export interface StoreState {
     setShowCornerLines: (show: boolean) => void
     setCornerLineColor: (color: number) => void
     setCornerLineOpacity: (opacity: number) => void
-}
-
-export interface BoxInfo {
-    id: number
-    group: number
-    dimensions?: {
-        width: number
-        depth: number
-        height: number
-    }
-    cells: Array<{ x: number; z: number }>
-    visible?: boolean
 }
 
 export type ValidKey = 's' | 'c' | 'h' | string

--- a/tests/geometry.test.ts
+++ b/tests/geometry.test.ts
@@ -234,7 +234,7 @@ describe('box generation', () => {
         expect(box.children).toHaveLength(1)
         expect(meshes(cell)).toHaveLength(2)
         expect(cell.visible).toBe(true)
-        expect(cell.userData.dimensions).toMatchObject({
+        expect(getGridBoxes(grid, 30)[0].dimensions).toMatchObject({
             width: 30,
             depth: 20,
         })
@@ -261,8 +261,8 @@ describe('box generation', () => {
         const combined = generateCustomBox(grid, 2, 4, false)
 
         expect(combined.children).toHaveLength(1)
-        expect(combined.children[0].userData.group).toBe(4)
-        expect(combined.children[0].userData.dimensions).toMatchObject({
+        expect(combined.children[0].name).toBe('group:4')
+        expect(getGridBoxes(grid, 30)[0].dimensions).toMatchObject({
             width: 60,
             depth: 40,
         })
@@ -272,11 +272,12 @@ describe('box generation', () => {
         const split = generateCustomBox(grid, 2, 4, false)
 
         expect(split.children).toHaveLength(2)
-        expect(split.children.map((child) => child.userData.group)).toEqual([
-            0, 0,
+        expect(split.children.map((child) => child.name)).toEqual([
+            'cell:0:0',
+            'cell:1:0',
         ])
         expect(
-            split.children.map((child) => child.userData.dimensions.width)
+            getGridBoxes(grid, 30).map((box) => box.dimensions.width)
         ).toEqual([25, 35])
         split.children.forEach(expectFiniteGeometry)
     })
@@ -293,18 +294,19 @@ describe('box generation', () => {
             ],
         ]
         const box = generateCustomBox(grid, 2, 0, true)
-        const combined = box.children.find(
-            (child) => child.userData.group === 7
+        const combined = box.children.find((child) => child.name === 'group:7')
+        const metadata = getGridBoxes(grid, 30).find(
+            (entry) => entry.id === 'group:7'
         )
 
         expect(combined).toBeDefined()
         expect(meshes(combined!)).toHaveLength(2)
-        expect(combined?.userData.cells).toEqual([
+        expect(metadata?.cells).toEqual([
             { x: 0, z: 0 },
             { x: 1, z: 0 },
             { x: 0, z: 1 },
         ])
-        expect(combined?.userData.dimensions).toMatchObject({
+        expect(metadata?.dimensions).toMatchObject({
             width: 30,
             depth: 70,
         })
@@ -432,14 +434,17 @@ describe('grid visibility', () => {
         expect(isGridBoxVisible(grid, box)).toBe(true)
 
         setGridBoxVisible(grid, box, false)
-        expect(grid[0].map((cell) => cell.visible)).toEqual([false, false])
-        expect(getGridBoxes(grid)[0].visible).toBe(false)
+        expect(grid[0].map((cell) => cell.visibility)).toEqual([
+            'hidden',
+            'hidden',
+        ])
+        expect(getGridBoxes(grid)[0].visibility).toBe('hidden')
         expect(generateCustomBox(grid, 2, 4, true).children[0].visible).toBe(
             false
         )
 
         setGridBoxVisible(grid, box, true)
-        expect(getGridBoxes(grid)[0].visible).toBe(true)
+        expect(getGridBoxes(grid)[0].visibility).toBe('visible')
     })
 
     it('handles empty grids as an edge case', () => {
@@ -460,7 +465,7 @@ describe('grid resizing', () => {
     it('preserves group and visibility while resizing physical dimensions', () => {
         const oldGrid: Grid = [
             [
-                { group: 1, visible: false, width: 50, depth: 50 },
+                { group: 1, visibility: 'hidden', width: 50, depth: 50 },
                 { group: 0, width: 50, depth: 50 },
             ],
             [
@@ -475,7 +480,7 @@ describe('grid resizing', () => {
         expect(resized[0]).toHaveLength(2)
         expect(resized[0][0]).toMatchObject({
             group: 1,
-            visible: false,
+            visibility: 'hidden',
             width: 100,
             depth: 100,
         })

--- a/tests/renderRuntime.test.ts
+++ b/tests/renderRuntime.test.ts
@@ -1,0 +1,124 @@
+import { generateCustomBox } from '@/lib/boxHelper'
+import { pickCurrentBox } from '@/lib/boxPicking'
+import { getGridBoxes } from '@/lib/gridVisibility'
+import { renderRuntime, setRenderedBoxGroup } from '@/lib/renderRuntime'
+import { useStore } from '@/lib/store'
+import type { Grid } from '@/lib/types'
+import * as THREE from 'three'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const standardColor = 0xcccccc
+const selectedColor = 0xff5500
+
+describe('renderer projections', () => {
+    afterEach(() => {
+        renderRuntime.cameraRef.current = null
+        renderRuntime.boxRef.current = null
+        renderRuntime.boxMeshes.clear()
+        useStore.setState({ selectedBoxIds: [] })
+        vi.restoreAllMocks()
+    })
+
+    it('reapplies selected IDs when geometry settings replace the mesh tree', () => {
+        const grid: Grid = [[{ group: 1, width: 30, depth: 20 }]]
+        useStore.setState({
+            grid,
+            selectedBoxIds: ['group:1'],
+            wallHeight: 30,
+            showCornerLines: false,
+        })
+
+        const initial = generateCustomBox(grid, 2, 4, true)
+        setRenderedBoxGroup(
+            initial,
+            useStore.getState().selectedBoxIds,
+            standardColor,
+            selectedColor
+        )
+
+        const rebuilt = generateCustomBox(grid, 3, 6, false)
+        setRenderedBoxGroup(
+            rebuilt,
+            useStore.getState().selectedBoxIds,
+            standardColor,
+            selectedColor
+        )
+
+        expect(renderRuntime.boxRef.current).toBe(rebuilt)
+        expect(meshColors(rebuilt.children[0])).toEqual([selectedColor])
+        expect(useStore.getState().selectedBoxIds).toEqual(['group:1'])
+        expect(
+            getGridBoxes(grid, 30).filter((box) =>
+                useStore.getState().selectedBoxIds.includes(box.id)
+            )
+        ).toMatchObject([{ id: 'group:1', group: 1 }])
+    })
+
+    it('raycasts the current camera and box tree after a replacement', () => {
+        const oldGroup = selectableGroup('cell:0:0')
+        const currentGroup = selectableGroup('cell:1:0')
+        const oldCamera = new THREE.PerspectiveCamera()
+        const currentCamera = new THREE.PerspectiveCamera()
+        renderRuntime.cameraRef.current = oldCamera
+        setRenderedBoxGroup(oldGroup, [], standardColor, selectedColor)
+
+        renderRuntime.cameraRef.current = currentCamera
+        setRenderedBoxGroup(currentGroup, [], standardColor, selectedColor)
+
+        const raycaster = new THREE.Raycaster()
+        const setFromCamera = vi
+            .spyOn(raycaster, 'setFromCamera')
+            .mockImplementation(() => undefined)
+        const intersectObjects = vi
+            .spyOn(raycaster, 'intersectObjects')
+            .mockReturnValue([
+                {
+                    object: currentGroup.children[0].children[0],
+                } as THREE.Intersection,
+            ])
+
+        expect(pickCurrentBox(raycaster, new THREE.Vector2())).toBe('cell:1:0')
+        expect(setFromCamera).toHaveBeenCalledWith(
+            expect.any(THREE.Vector2),
+            currentCamera
+        )
+        expect(intersectObjects).toHaveBeenCalledWith(
+            currentGroup.children,
+            true
+        )
+        expect(intersectObjects).not.toHaveBeenCalledWith(
+            oldGroup.children,
+            true
+        )
+    })
+})
+
+function selectableGroup(id: 'cell:0:0' | 'cell:1:0'): THREE.Group {
+    const root = new THREE.Group()
+    const box = new THREE.Group()
+    box.name = id
+    box.add(
+        new THREE.Mesh(
+            new THREE.BoxGeometry(1, 1, 1),
+            new THREE.MeshBasicMaterial()
+        )
+    )
+    root.add(box)
+    return root
+}
+
+function meshColors(object: THREE.Object3D): number[] {
+    const colors = new Set<number>()
+    object.traverse((child) => {
+        if (!(child instanceof THREE.Mesh)) return
+        const materials = Array.isArray(child.material)
+            ? child.material
+            : [child.material]
+        materials.forEach((material) => {
+            if ('color' in material && material.color instanceof THREE.Color) {
+                colors.add(material.color.getHex())
+            }
+        })
+    })
+    return [...colors]
+}


### PR DESCRIPTION
## Summary

- Preserve selected box highlighting whenever geometry is rebuilt.
- Resolve context-menu raycasts against the current camera and rendered box tree.
- Keep the domain model serializable and renderer state isolated from Zustand.
- Add regression coverage for redraw selection persistence and current-tree picking.

## Why

Geometry-setting updates replace the Three.js group while selected IDs remain unchanged, so the UI still reported selected boxes but the replacement meshes lost their selected color. The context-menu effect also captured an older group and camera, causing right-clicks after redraws to raycast disposed or hidden geometry.

The renderer projection now reapplies selection colors whenever a new mesh tree is installed, and box picking reads the current runtime refs at event time.

## Validation

- ESLint
- TypeScript
- 20 Vitest tests
- Next.js production build
- Browser verification after a geometry-only redraw