### PR TITLE
Store selection by stable IDs

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import ActionsBar from '@/components/ActionsBar'
 import BoxContextMenu from '@/components/BoxContextMenu'
 import HiddenBoxesDisplay from '@/components/HiddenBoxesDisplay'
 import { generateCustomBox } from '@/lib/boxHelper'
+import { pickCurrentBox } from '@/lib/boxPicking'
 import { cameraSettings } from '@/lib/defaults'
 import { combineGridBoxes, getNextAvailableGroupId } from '@/lib/gridCombine'
 import { gridMatchesLayout, resizeGrid } from '@/lib/gridHelper'
@@ -19,7 +20,7 @@ import {
     setRenderedBoxGroup,
 } from '@/lib/renderRuntime'
 import { useStore } from '@/lib/store'
-import type { Grid, SelectionId } from '@/lib/types'
+import type { Grid } from '@/lib/types'
 import { useEffect } from 'react'
 import * as THREE from 'three'
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
@@ -225,23 +226,8 @@ export default function Home() {
             const rect = renderer.domElement.getBoundingClientRect()
             mouse.x = ((event.clientX - rect.left) / rect.width) * 2 - 1
             mouse.y = -((event.clientY - rect.top) / rect.height) * 2 + 1
-            raycaster.setFromCamera(mouse, camera)
-
-            const hits = raycaster.intersectObjects(scene.children, true)
-            if (!hits.length) return
-
-            const hit = hits.find(({ object }) => {
-                if (!(object instanceof THREE.Mesh)) return false
-                //@ts-ignore
-                const idx = object.parent.children.indexOf(object)
-                const isWall = idx === 0
-                const isBottom = useStore.getState().generateBottom && idx === 1
-                return isWall || isBottom
-            })
-            if (!hit) return
-
-            const boxId = (hit.object as THREE.Mesh).parent?.name as SelectionId
-            if (!renderRuntime.boxMeshes.has(boxId)) return
+            const boxId = pickCurrentBox(raycaster, mouse)
+            if (!boxId) return
 
             const selectedBoxIds = isMultiSelect
                 ? [...useStore.getState().selectedBoxIds]

--- a/lib/boxPicking.ts
+++ b/lib/boxPicking.ts
@@ -16,6 +16,7 @@ export function pickCurrentBox(
         .find(({ object }) => {
             const parent = object.parent
             return (
+                object instanceof THREE.Mesh &&
                 parent instanceof THREE.Group &&
                 renderRuntime.boxMeshes.has(parent.name as SelectionId)
             )

--- a/tests/renderRuntime.test.ts
+++ b/tests/renderRuntime.test.ts
@@ -20,10 +20,15 @@ describe('renderer projections', () => {
     })
 
     it('reapplies selected IDs when geometry settings replace the mesh tree', () => {
-        const grid: Grid = [[{ group: 1, width: 30, depth: 20 }]]
+        const grid: Grid = [
+            [
+                { group: 1, width: 30, depth: 20 },
+                { group: 0, width: 20, depth: 20 },
+            ],
+        ]
         useStore.setState({
             grid,
-            selectedBoxIds: ['group:1'],
+            selectedBoxIds: ['group:1', 'cell:1:0'],
             wallHeight: 30,
             showCornerLines: false,
         })
@@ -46,12 +51,19 @@ describe('renderer projections', () => {
 
         expect(renderRuntime.boxRef.current).toBe(rebuilt)
         expect(meshColors(rebuilt.children[0])).toEqual([selectedColor])
-        expect(useStore.getState().selectedBoxIds).toEqual(['group:1'])
+        expect(meshColors(rebuilt.children[1])).toEqual([selectedColor])
+        expect(useStore.getState().selectedBoxIds).toEqual([
+            'group:1',
+            'cell:1:0',
+        ])
         expect(
             getGridBoxes(grid, 30).filter((box) =>
                 useStore.getState().selectedBoxIds.includes(box.id)
             )
-        ).toMatchObject([{ id: 'group:1', group: 1 }])
+        ).toMatchObject([
+            { id: 'group:1', group: 1 },
+            { id: 'cell:1:0', group: 0 },
+        ])
     })
 
     it('raycasts the current camera and box tree after a replacement', () => {
@@ -90,6 +102,25 @@ describe('renderer projections', () => {
             oldGroup.children,
             true
         )
+    })
+
+    it('ignores non-mesh render objects when resolving a selection ID', () => {
+        const group = selectableGroup('cell:0:0')
+        const decoration = new THREE.LineSegments(
+            new THREE.BufferGeometry(),
+            new THREE.LineBasicMaterial()
+        )
+        group.children[0].add(decoration)
+        renderRuntime.cameraRef.current = new THREE.PerspectiveCamera()
+        setRenderedBoxGroup(group, [], standardColor, selectedColor)
+
+        const raycaster = new THREE.Raycaster()
+        vi.spyOn(raycaster, 'setFromCamera').mockImplementation(() => undefined)
+        vi.spyOn(raycaster, 'intersectObjects').mockReturnValue([
+            { object: decoration } as unknown as THREE.Intersection,
+        ])
+
+        expect(pickCurrentBox(raycaster, new THREE.Vector2())).toBeNull()
     })
 })
 


### PR DESCRIPTION
## What changed

- Route left-click selection through the Three.js picking adapter.
- Resolve only mesh hits to stable `group:*` and `cell:*` IDs.
- Extend redraw tests to cover grouped boxes and individual cells across regenerated mesh trees.

## Why

Selection state must survive redraws and regeneration without retaining disposed Three.js objects. Keeping IDs in application state and resolving them in the renderer prevents stale object references and keeps selection highlighting valid after geometry replacement.

## Validation

- Vitest: 21 passed
- ESLint
- TypeScript
- Prettier
- Next.js production build