### PR TITLE
TW-204 Make generation functions pure

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -142,12 +142,17 @@ export default function Home() {
             if (!scene || !currentBox) return
 
             removeAndDisposeObject(scene, currentBox)
-            const newBox = generateCustomBox(
-                currentState.grid,
-                currentState.wallThickness,
-                currentState.cornerRadius,
-                currentState.generateBottom
-            )
+            const newBox = generateCustomBox(currentState.grid, {
+                wallThickness: currentState.wallThickness,
+                cornerRadius: currentState.cornerRadius,
+                wallHeight: currentState.wallHeight,
+                generateBottom: currentState.generateBottom,
+                cornerLines: {
+                    show: currentState.showCornerLines,
+                    color: currentState.cornerLineColor,
+                    opacity: currentState.cornerLineOpacity,
+                },
+            })
             setRenderedBoxGroup(
                 newBox,
                 currentState.selectedBoxIds,
@@ -288,6 +293,8 @@ export default function Home() {
         wallHeight,
         redrawTrigger,
         showCornerLines,
+        cornerLineColor,
+        cornerLineOpacity,
         setGrid,
     } = state
 
@@ -321,12 +328,17 @@ export default function Home() {
             setGrid(grid)
         }
 
-        const box = generateCustomBox(
-            grid,
+        const box = generateCustomBox(grid, {
             wallThickness,
             cornerRadius,
-            generateBottom
-        )
+            wallHeight,
+            generateBottom,
+            cornerLines: {
+                show: showCornerLines,
+                color: cornerLineColor,
+                opacity: cornerLineOpacity,
+            },
+        })
         const currentState = useStore.getState()
         setRenderedBoxGroup(
             box,
@@ -348,6 +360,8 @@ export default function Home() {
         modelGrid,
         redrawTrigger,
         showCornerLines,
+        cornerLineColor,
+        cornerLineOpacity,
         setGrid,
     ])
 

--- a/lib/boxHelper.ts
+++ b/lib/boxHelper.ts
@@ -1,18 +1,28 @@
 import {
+    createCornerLines,
     getOutline,
     getRoundedOutline,
     offsetPolygonCCW,
 } from '@/lib/lineHelper'
-import { useStore } from '@/lib/store'
 import { Cell, Grid } from '@/lib/types'
 import * as THREE from 'three'
 import { buildBottomMesh, buildWallMesh } from './meshHelper'
 
+export type BoxGenerationOptions = {
+    wallThickness: number
+    cornerRadius: number
+    wallHeight: number
+    generateBottom: boolean
+    cornerLines: {
+        show: boolean
+        color: number
+        opacity: number
+    }
+}
+
 export function generateCustomBox(
     grid: Grid,
-    wall_thickness: number,
-    corner_radius: number,
-    generate_bottom: boolean
+    options: BoxGenerationOptions
 ): THREE.Group {
     if (grid.length === 0 || grid[0].length === 0) {
         throw new Error('Cannot generate box geometry for an empty grid.')
@@ -48,20 +58,20 @@ export function generateCustomBox(
         const rawO = getOutline(grid, id)
         if (!rawO.length) return
 
-        const rawI = offsetPolygonCCW(rawO, wall_thickness)
+        const rawI = offsetPolygonCCW(rawO, options.wallThickness)
         const outR = getRoundedOutline(
             rawO,
-            corner_radius,
+            options.cornerRadius,
             5,
-            corner_radius,
-            wall_thickness
+            options.cornerRadius,
+            options.wallThickness
         )
         const inR = getRoundedOutline(
             rawI,
-            corner_radius - wall_thickness,
+            options.cornerRadius - options.wallThickness,
             5,
-            corner_radius,
-            wall_thickness
+            options.cornerRadius,
+            options.wallThickness
         )
 
         const xCoords = cellsForThisId.map((cell) => cell.x)
@@ -78,15 +88,17 @@ export function generateCustomBox(
         boxGroup.name = `group:${id}`
         boxGroup.visible = isBoxVisible
 
-        boxGroup.add(buildWallMesh(outR, inR))
-        if (generate_bottom) boxGroup.add(buildBottomMesh(outR, wall_thickness))
+        boxGroup.add(buildWallMesh(outR, inR, options.wallHeight))
+        if (options.generateBottom)
+            boxGroup.add(buildBottomMesh(outR, options.wallThickness))
 
-        if (useStore.getState().showCornerLines) {
+        if (options.cornerLines.show) {
             const cornerLines = createCornerLines(
                 outR,
-                useStore.getState().wallHeight,
-                useStore.getState().cornerLineColor,
-                useStore.getState().cornerLineOpacity
+                options.wallHeight,
+                options.cornerLines.color,
+                options.cornerLines.opacity,
+                0
             )
             boxGroup.add(cornerLines)
         }
@@ -111,20 +123,20 @@ export function generateCustomBox(
                 ],
             ]
             const rawO = getOutline(singleGrid, 0)
-            const rawI = offsetPolygonCCW(rawO, wall_thickness)
+            const rawI = offsetPolygonCCW(rawO, options.wallThickness)
             const outR = getRoundedOutline(
                 rawO,
-                corner_radius,
+                options.cornerRadius,
                 5,
-                corner_radius,
-                wall_thickness
+                options.cornerRadius,
+                options.wallThickness
             )
             const inR = getRoundedOutline(
                 rawI,
-                corner_radius - wall_thickness,
+                options.cornerRadius - options.wallThickness,
                 5,
-                corner_radius,
-                wall_thickness
+                options.cornerRadius,
+                options.wallThickness
             )
             const x0 = cumW[x],
                 z0 = cumD[z]
@@ -140,24 +152,26 @@ export function generateCustomBox(
             const cellGroup = new THREE.Group()
             cellGroup.name = `cell:${x}:${z}`
             cellGroup.visible = cell.visibility !== 'hidden'
-            cellGroup.add(buildWallMesh(outR, inR))
-            if (generate_bottom)
-                cellGroup.add(buildBottomMesh(outR, wall_thickness))
+            cellGroup.add(buildWallMesh(outR, inR, options.wallHeight))
+            if (options.generateBottom)
+                cellGroup.add(buildBottomMesh(outR, options.wallThickness))
 
-            if (useStore.getState().showCornerLines) {
+            if (options.cornerLines.show) {
                 const outerLines = createCornerLines(
                     outR,
-                    useStore.getState().wallHeight,
-                    useStore.getState().cornerLineColor,
-                    useStore.getState().cornerLineOpacity
+                    options.wallHeight,
+                    options.cornerLines.color,
+                    options.cornerLines.opacity,
+                    0
                 )
                 cellGroup.add(outerLines)
 
                 const innerLines = createCornerLines(
                     inR,
-                    useStore.getState().wallHeight,
-                    useStore.getState().cornerLineColor,
-                    useStore.getState().cornerLineOpacity,
+                    options.wallHeight,
+                    options.cornerLines.color,
+                    options.cornerLines.opacity,
+                    options.generateBottom ? options.wallThickness : 0,
                     true
                 )
                 cellGroup.add(innerLines)
@@ -168,56 +182,4 @@ export function generateCustomBox(
     }
 
     return group
-}
-
-function createCornerLines(
-    outlinePoints: THREE.Vector2[],
-    height: number,
-    color: number,
-    opacity: number,
-    inner: boolean = false
-): THREE.LineSegments {
-    const geometry = new THREE.BufferGeometry()
-    const positions: number[] = []
-
-    outlinePoints.forEach((point) => {
-        positions.push(point.x, 0, point.y) // bottom
-        positions.push(point.x, height, point.y) // top
-    })
-
-    for (let i = 0; i < outlinePoints.length; i++) {
-        const current = outlinePoints[i]
-        const next = outlinePoints[(i + 1) % outlinePoints.length]
-
-        if (inner && useStore.getState().generateBottom) {
-            positions.push(
-                current.x,
-                useStore.getState().wallThickness,
-                current.y
-            )
-            positions.push(next.x, useStore.getState().wallThickness, next.y)
-        } else {
-            positions.push(current.x, 0, current.y)
-            positions.push(next.x, 0, next.y)
-        }
-
-        positions.push(current.x, height, current.y)
-        positions.push(next.x, height, next.y)
-    }
-
-    geometry.setAttribute(
-        'position',
-        new THREE.Float32BufferAttribute(positions, 3)
-    )
-
-    const material = new THREE.LineBasicMaterial({
-        color,
-        opacity,
-        transparent: true,
-        linewidth: 1,
-    })
-
-    const lines = new THREE.LineSegments(geometry, material)
-    lines.name = 'corner-lines'
-    return lines
 }

--- a/lib/exportUtils.ts
+++ b/lib/exportUtils.ts
@@ -15,12 +15,17 @@ export function handleStlExport(): void {
 
     // Wrap & rotate so Three's Y-up becomes STL Z-up
     const tmpScene = new THREE.Scene()
-    const box = generateCustomBox(
-        grid,
-        state.wallThickness,
-        state.cornerRadius,
-        state.generateBottom
-    )
+    const box = generateCustomBox(grid, {
+        wallThickness: state.wallThickness,
+        cornerRadius: state.cornerRadius,
+        wallHeight: state.wallHeight,
+        generateBottom: state.generateBottom,
+        cornerLines: {
+            show: false,
+            color: state.cornerLineColor,
+            opacity: state.cornerLineOpacity,
+        },
+    })
     removeHiddenObjects(box)
     box.position.set(0, 0, 0)
     box.rotation.set(Math.PI / 2, 0, 0)

--- a/lib/lineHelper.ts
+++ b/lib/lineHelper.ts
@@ -147,3 +147,47 @@ export function getRoundedOutline(
     const ptsOut = path.getPoints(N * segmentsPerCorner)
     return ptsOut.map((p) => new THREE.Vector2(p.x, p.y))
 }
+
+export function createCornerLines(
+    outlinePoints: THREE.Vector2[],
+    height: number,
+    color: number,
+    opacity: number,
+    bottomThickness: number,
+    inner = false
+): THREE.LineSegments {
+    const geometry = new THREE.BufferGeometry()
+    const positions: number[] = []
+
+    outlinePoints.forEach((point) => {
+        positions.push(point.x, 0, point.y)
+        positions.push(point.x, height, point.y)
+    })
+
+    for (let i = 0; i < outlinePoints.length; i++) {
+        const current = outlinePoints[i]
+        const next = outlinePoints[(i + 1) % outlinePoints.length]
+        const lowerHeight = inner ? bottomThickness : 0
+
+        positions.push(current.x, lowerHeight, current.y)
+        positions.push(next.x, lowerHeight, next.y)
+        positions.push(current.x, height, current.y)
+        positions.push(next.x, height, next.y)
+    }
+
+    geometry.setAttribute(
+        'position',
+        new THREE.Float32BufferAttribute(positions, 3)
+    )
+
+    const material = new THREE.LineBasicMaterial({
+        color,
+        opacity,
+        transparent: true,
+        linewidth: 1,
+    })
+
+    const lines = new THREE.LineSegments(geometry, material)
+    lines.name = 'corner-lines'
+    return lines
+}

--- a/lib/meshHelper.ts
+++ b/lib/meshHelper.ts
@@ -1,12 +1,11 @@
 import { material } from '@/lib/defaults'
-import { useStore } from '@/lib/store'
 import * as THREE from 'three'
 
 export function buildWallMesh(
     outerPts: THREE.Vector2[],
-    innerPts: THREE.Vector2[]
+    innerPts: THREE.Vector2[],
+    wallHeight: number
 ): THREE.Mesh {
-    const wallHeight = useStore.getState().wallHeight
     const shape = new THREE.Shape()
     if (outerPts.length) {
         shape.moveTo(outerPts[0].x, outerPts[0].y)

--- a/tests/geometry.test.ts
+++ b/tests/geometry.test.ts
@@ -1,4 +1,4 @@
-import { generateCustomBox } from '@/lib/boxHelper'
+import { BoxGenerationOptions, generateCustomBox } from '@/lib/boxHelper'
 import {
     canCombineGridBoxes,
     combineGridBoxes,
@@ -34,6 +34,19 @@ function meshes(object: THREE.Object3D): THREE.Mesh[] {
         if (child instanceof THREE.Mesh) result.push(child)
     })
     return result
+}
+
+function generationOptions(
+    overrides: Partial<BoxGenerationOptions> = {}
+): BoxGenerationOptions {
+    return {
+        wallThickness: 2,
+        cornerRadius: 4,
+        wallHeight: 30,
+        generateBottom: true,
+        cornerLines: { show: false, color: 0x000000, opacity: 0.25 },
+        ...overrides,
+    }
 }
 
 function expectFiniteGeometry(object: THREE.Object3D): void {
@@ -227,7 +240,7 @@ describe('box generation', () => {
 
     it('generates valid wall and bottom meshes for rectangular boxes', () => {
         const grid: Grid = [[{ group: 0, width: 30, depth: 20 }]]
-        const box = generateCustomBox(grid, 2, 4, true)
+        const box = generateCustomBox(grid, generationOptions())
         const cell = box.children[0]
         const size = boundingSize(cell)
 
@@ -247,8 +260,17 @@ describe('box generation', () => {
     it('omits bottom geometry when bottom generation is disabled', () => {
         const grid: Grid = [[{ group: 0, width: 30, depth: 20 }]]
 
-        expect(meshes(generateCustomBox(grid, 2, 4, false))).toHaveLength(1)
-        expect(meshes(generateCustomBox(grid, 2, 4, true))).toHaveLength(2)
+        expect(
+            meshes(
+                generateCustomBox(
+                    grid,
+                    generationOptions({ generateBottom: false })
+                )
+            )
+        ).toHaveLength(1)
+        expect(
+            meshes(generateCustomBox(grid, generationOptions()))
+        ).toHaveLength(2)
     })
 
     it('generates one box for combined cells and split boxes after ungrouping', () => {
@@ -258,7 +280,10 @@ describe('box generation', () => {
                 { group: 4, width: 35, depth: 40 },
             ],
         ]
-        const combined = generateCustomBox(grid, 2, 4, false)
+        const combined = generateCustomBox(
+            grid,
+            generationOptions({ generateBottom: false })
+        )
 
         expect(combined.children).toHaveLength(1)
         expect(combined.children[0].name).toBe('group:4')
@@ -269,7 +294,10 @@ describe('box generation', () => {
 
         grid[0][0].group = 0
         grid[0][1].group = 0
-        const split = generateCustomBox(grid, 2, 4, false)
+        const split = generateCustomBox(
+            grid,
+            generationOptions({ generateBottom: false })
+        )
 
         expect(split.children).toHaveLength(2)
         expect(split.children.map((child) => child.name)).toEqual([
@@ -293,7 +321,10 @@ describe('box generation', () => {
                 { group: 0, width: 20, depth: 40 },
             ],
         ]
-        const box = generateCustomBox(grid, 2, 0, true)
+        const box = generateCustomBox(
+            grid,
+            generationOptions({ cornerRadius: 0 })
+        )
         const combined = box.children.find((child) => child.name === 'group:7')
         const metadata = getGridBoxes(grid, 30).find(
             (entry) => entry.id === 'group:7'
@@ -348,9 +379,40 @@ describe('box generation', () => {
             ],
         ]
 
-        expect(() => generateCustomBox(grid, 2, 0, true)).toThrow(
+        expect(() =>
+            generateCustomBox(grid, generationOptions({ cornerRadius: 0 }))
+        ).toThrow(
             'Cannot build a single outline for group 6 with disconnected cells or holes.'
         )
+    })
+
+    it('uses explicit options instead of Zustand geometry state', () => {
+        const grid: Grid = [[{ group: 0, width: 30, depth: 20 }]]
+        const options = generationOptions({
+            wallHeight: 18,
+            generateBottom: true,
+            cornerLines: { show: true, color: 0x123456, opacity: 0.4 },
+        })
+
+        useStore.setState({
+            wallHeight: 99,
+            generateBottom: false,
+            wallThickness: 8,
+            showCornerLines: false,
+            cornerLineColor: 0xffffff,
+            cornerLineOpacity: 1,
+        })
+
+        const box = generateCustomBox(grid, options)
+        const size = boundingSize(box)
+        const lines = box.getObjectsByProperty('name', 'corner-lines')
+
+        expect(size.y).toBeCloseTo(18)
+        expect(meshes(box)).toHaveLength(2)
+        expect(lines).toHaveLength(2)
+        expect((lines[0] as THREE.LineSegments).material).toMatchObject({
+            opacity: 0.4,
+        })
     })
 })
 
@@ -439,9 +501,9 @@ describe('grid visibility', () => {
             'hidden',
         ])
         expect(getGridBoxes(grid)[0].visibility).toBe('hidden')
-        expect(generateCustomBox(grid, 2, 4, true).children[0].visible).toBe(
-            false
-        )
+        expect(
+            generateCustomBox(grid, generationOptions()).children[0].visible
+        ).toBe(false)
 
         setGridBoxVisible(grid, box, true)
         expect(getGridBoxes(grid)[0].visibility).toBe('visible')
@@ -455,7 +517,7 @@ describe('grid visibility', () => {
         expect(() => getOutline([], 0)).toThrow(
             'Cannot build an outline for an empty grid.'
         )
-        expect(() => generateCustomBox([], 2, 4, true)).toThrow(
+        expect(() => generateCustomBox([], generationOptions())).toThrow(
             'Cannot generate box geometry for an empty grid.'
         )
     })

--- a/tests/geometry.test.ts
+++ b/tests/geometry.test.ts
@@ -74,6 +74,37 @@ function boundingSize(object: THREE.Object3D): THREE.Vector3 {
     return size
 }
 
+function generationSignature(object: THREE.Object3D): unknown[] {
+    const signature: unknown[] = []
+
+    object.traverse((child) => {
+        if (!(
+            child instanceof THREE.Mesh || child instanceof THREE.LineSegments
+        ))
+            return
+
+        const position = child.geometry.getAttribute('position')
+        const materials = Array.isArray(child.material)
+            ? child.material
+            : [child.material]
+
+        signature.push({
+            type: child.type,
+            name: child.name,
+            position: Array.from(position.array),
+            materials: materials.map((material) => ({
+                color:
+                    'color' in material && material.color instanceof THREE.Color
+                        ? material.color.getHex()
+                        : null,
+                opacity: material.opacity,
+            })),
+        })
+    })
+
+    return signature
+}
+
 function footprintPoints(object: THREE.Object3D): Set<string> {
     object.updateMatrixWorld(true)
 
@@ -386,33 +417,76 @@ describe('box generation', () => {
         )
     })
 
-    it('uses explicit options instead of Zustand geometry state', () => {
+    it('makes every generation option observable in the output', () => {
         const grid: Grid = [[{ group: 0, width: 30, depth: 20 }]]
         const options = generationOptions({
+            wallThickness: 2,
+            cornerRadius: 6,
             wallHeight: 18,
             generateBottom: true,
             cornerLines: { show: true, color: 0x123456, opacity: 0.4 },
         })
-
-        useStore.setState({
-            wallHeight: 99,
-            generateBottom: false,
-            wallThickness: 8,
-            showCornerLines: false,
-            cornerLineColor: 0xffffff,
-            cornerLineOpacity: 1,
-        })
-
         const box = generateCustomBox(grid, options)
         const size = boundingSize(box)
+        const boxMeshes = meshes(box)
         const lines = box.getObjectsByProperty('name', 'corner-lines')
+        const sharpBox = generateCustomBox(grid, {
+            ...options,
+            cornerRadius: 0,
+        })
+        const roundedPositionCount =
+            boxMeshes[0].geometry.getAttribute('position').count
+        const sharpPositionCount =
+            meshes(sharpBox)[0].geometry.getAttribute('position').count
+        const lineMaterial = (lines[0] as THREE.LineSegments)
+            .material as THREE.LineBasicMaterial
 
         expect(size.y).toBeCloseTo(18)
-        expect(meshes(box)).toHaveLength(2)
+        expect(boxMeshes).toHaveLength(2)
+        expect(boundingSize(boxMeshes[1]).y).toBeCloseTo(2)
+        expect(roundedPositionCount).toBeGreaterThan(sharpPositionCount)
         expect(lines).toHaveLength(2)
-        expect((lines[0] as THREE.LineSegments).material).toMatchObject({
-            opacity: 0.4,
-        })
+        expect(lineMaterial.color.getHex()).toBe(0x123456)
+        expect(lineMaterial.opacity).toBe(0.4)
+    })
+
+    const explicitOptions = generationOptions({
+        wallThickness: 2,
+        cornerRadius: 6,
+        wallHeight: 18,
+        generateBottom: true,
+        cornerLines: { show: true, color: 0x123456, opacity: 0.4 },
+    })
+    const matchingStoreState = {
+        wallThickness: explicitOptions.wallThickness,
+        cornerRadius: explicitOptions.cornerRadius,
+        wallHeight: explicitOptions.wallHeight,
+        generateBottom: explicitOptions.generateBottom,
+        showCornerLines: explicitOptions.cornerLines.show,
+        cornerLineColor: explicitOptions.cornerLines.color,
+        cornerLineOpacity: explicitOptions.cornerLines.opacity,
+    }
+
+    it.each([
+        ['wall thickness', { wallThickness: 8 }],
+        ['corner radius', { cornerRadius: 0 }],
+        ['wall height', { wallHeight: 99 }],
+        ['bottom generation', { generateBottom: false }],
+        ['corner-line visibility', { showCornerLines: false }],
+        ['corner-line color', { cornerLineColor: 0xffffff }],
+        ['corner-line opacity', { cornerLineOpacity: 1 }],
+    ])('ignores Zustand %s', (_, conflictingState) => {
+        const grid: Grid = [[{ group: 0, width: 30, depth: 20 }]]
+        useStore.setState(matchingStoreState)
+        const expected = generationSignature(
+            generateCustomBox(grid, explicitOptions)
+        )
+
+        useStore.setState(conflictingState)
+
+        expect(
+            generationSignature(generateCustomBox(grid, explicitOptions))
+        ).toEqual(expected)
     })
 })
 

--- a/tests/renderRuntime.test.ts
+++ b/tests/renderRuntime.test.ts
@@ -1,4 +1,4 @@
-import { generateCustomBox } from '@/lib/boxHelper'
+import { BoxGenerationOptions, generateCustomBox } from '@/lib/boxHelper'
 import { pickCurrentBox } from '@/lib/boxPicking'
 import { getGridBoxes } from '@/lib/gridVisibility'
 import { renderRuntime, setRenderedBoxGroup } from '@/lib/renderRuntime'
@@ -9,6 +9,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const standardColor = 0xcccccc
 const selectedColor = 0xff5500
+const generationOptions: BoxGenerationOptions = {
+    wallThickness: 2,
+    cornerRadius: 4,
+    wallHeight: 30,
+    generateBottom: true,
+    cornerLines: { show: false, color: 0x000000, opacity: 0.25 },
+}
 
 describe('renderer projections', () => {
     afterEach(() => {
@@ -33,7 +40,7 @@ describe('renderer projections', () => {
             showCornerLines: false,
         })
 
-        const initial = generateCustomBox(grid, 2, 4, true)
+        const initial = generateCustomBox(grid, generationOptions)
         setRenderedBoxGroup(
             initial,
             useStore.getState().selectedBoxIds,
@@ -41,7 +48,12 @@ describe('renderer projections', () => {
             selectedColor
         )
 
-        const rebuilt = generateCustomBox(grid, 3, 6, false)
+        const rebuilt = generateCustomBox(grid, {
+            ...generationOptions,
+            wallThickness: 3,
+            cornerRadius: 6,
+            generateBottom: false,
+        })
         setRenderedBoxGroup(
             rebuilt,
             useStore.getState().selectedBoxIds,


### PR DESCRIPTION
## What changed

- Replaced `generateCustomBox`'s positional arguments and hidden Zustand reads with a typed, explicit generation-options object.
- Passed wall height directly into the wall mesh helper.
- Moved corner-line creation into the line helper and made height, color, opacity, bottom thickness, and inner/outer behavior explicit inputs.
- Updated UI, export, and test call sites; STL export now explicitly omits decorative corner lines.
- Added table-driven regression coverage that independently conflicts every generation option with Zustand and compares the full geometry/material signature.
- Added direct assertions for wall thickness, corner radius, wall height, bottom presence, corner-line visibility, color, and opacity.

## Why

Geometry output previously depended on ambient UI state, so identical function arguments could produce different meshes and helper lines. Explicit inputs make generation deterministic, reusable outside React, and straightforward to test.

## Impact

Rendering behavior remains the same for the app, while geometry helpers can now be used independently of Zustand. Callers must provide the full generation configuration.

## Validation

- `npm test` (29 tests)
- `npm run lint`
- `npx tsc --noEmit`
- `git diff --check`

Linear: TW-204
