### PR TITLE
Preserve wall settings when resizing grid

### DIFF
--- a/lib/store.ts
+++ b/lib/store.ts
@@ -73,6 +73,6 @@ function setModelParameter<K extends keyof ModelParameters>(
     value: number
 ): number {
     const next = sanitizeModelParameters({ ...get(), [key]: value }, get())
-    set(next)
+    set({ [key]: next[key] } as Partial<StoreState>)
     return next[key]
 }

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -1,0 +1,42 @@
+import { defaultModelParameters } from '@/lib/parameterValidation'
+import { useStore } from '@/lib/store'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+describe('model parameter store', () => {
+    beforeEach(() => {
+        useStore.setState(defaultModelParameters)
+    })
+
+    it.each([
+        ['total width', 'totalWidth', 'setTotalWidth', 201],
+        ['total depth', 'totalDepth', 'setTotalDepth', 201],
+        ['max box width', 'maxBoxWidth', 'setMaxBoxWidth', 149],
+        ['max box depth', 'maxBoxDepth', 'setMaxBoxDepth', 149],
+    ] as const)(
+        'preserves wall settings when changing %s across a segment boundary',
+        (_label, parameter, setter, value) => {
+            const initial = useStore.getState()
+
+            initial[setter](value)
+
+            const updated = useStore.getState()
+            expect(updated[parameter]).toBe(value)
+            expect(updated.wallThickness).toBe(initial.wallThickness)
+            expect(updated.cornerRadius).toBe(initial.cornerRadius)
+        }
+    )
+
+    it('still clamps the parameter that is being changed', () => {
+        const state = useStore.getState()
+
+        expect(state.setWallThickness(999)).toBe(15)
+        expect(state.setCornerRadius(999)).toBe(25)
+        expect(state.setTotalWidth(-10)).toBe(1)
+
+        expect(useStore.getState()).toMatchObject({
+            wallThickness: 15,
+            cornerRadius: 25,
+            totalWidth: 1,
+        })
+    })
+})


### PR DESCRIPTION
## What changed

- Commit only the model parameter the user edited instead of the sanitizer's entire parameter snapshot.
- Add regression tests for total width, total depth, max box width, and max box depth changes.
- Keep clamping behavior for the parameter being edited.

## Why

Dimension setters passed the full store through `sanitizeModelParameters()` and then wrote every returned value back. When a resize created a small remainder segment, validation clamped wall thickness and corner radius and permanently replaced the user's settings.

The store now uses the sanitized value only for the requested field, so dimension changes no longer modify unrelated wall settings.

## Impact

Large grid-size changes preserve the configured wall thickness and corner radius while individual parameter validation continues to work.

## Validation

- `npm test` — 26 tests passed
- `npm run lint`
- `npx tsc --noEmit`
- Browser reproduction: changing total width from 150 mm to 201 mm with max box width 100 mm preserves wall thickness 2 mm and corner radius 4 mm