### PR TITLE
TW-206 Validate combine topology

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import '@/app/globals.css'
 import Sidebar from '@/components/Sidebar'
+import { Toaster } from '@/components/ui/sonner'
 import type { Metadata } from 'next'
 import localFont from 'next/font/local'
 import Script from 'next/script'
@@ -147,6 +148,7 @@ export default function RootLayout({
             >
                 <Sidebar />
                 <main className="flex-grow overflow-hidden">{children}</main>
+                <Toaster position="top-center" richColors />
             </body>
             <Script
                 defer

--- a/components/ActionsBar.tsx
+++ b/components/ActionsBar.tsx
@@ -14,7 +14,7 @@ import {
     TooltipTrigger,
 } from '@/components/ui/tooltip'
 import type { GridCommands } from '@/hooks/useGridCommands'
-import { canCombineGridBoxes } from '@/lib/gridCombine'
+import { validateGridBoxCombination } from '@/lib/gridCombine'
 import { getGridBoxes } from '@/lib/gridVisibility'
 import { useStore } from '@/lib/store'
 import {
@@ -45,10 +45,12 @@ export default function ActionsBar({
     )
     const enableClearSelection = selectedBoxes.length > 0
     const canSplit = selectedBoxes.length === 1 && selectedBoxes[0].group !== 0
-    const canCombine =
-        selectedBoxes.length >= 2 &&
-        canCombineGridBoxes(store.grid, selectedBoxes)
-    const canUseBoxAction = canSplit || canCombine
+    const combineValidation = validateGridBoxCombination(
+        store.grid,
+        selectedBoxes
+    )
+    const canAttemptCombine = selectedBoxes.length >= 2
+    const canUseBoxAction = canSplit || canAttemptCombine
 
     return (
         <div className="lg:bottom-18 lg:ml-auto lg:-right-6 z-10 transform relative lg:w-fit">
@@ -124,7 +126,7 @@ export default function ActionsBar({
                             onClick={() => {
                                 if (canSplit) {
                                     commands.splitSelection()
-                                } else if (canCombine) {
+                                } else if (canAttemptCombine) {
                                     commands.combineSelection()
                                 }
                             }}
@@ -138,6 +140,9 @@ export default function ActionsBar({
                         <TooltipContent>
                             {canSplit ? (
                                 <p>Split Combined Box (S)</p>
+                            ) : canAttemptCombine &&
+                              !combineValidation.valid ? (
+                                <p>{combineValidation.message}</p>
                             ) : (
                                 <p>Combine Selected Boxes (C)</p>
                             )}

--- a/components/BoxContextMenu.tsx
+++ b/components/BoxContextMenu.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { GridCommands } from '@/hooks/useGridCommands'
-import { canCombineGridBoxes } from '@/lib/gridCombine'
+import { validateGridBoxCombination } from '@/lib/gridCombine'
 import { getBoxById, getGridBoxes } from '@/lib/gridVisibility'
 import { useStore } from '@/lib/store'
 import type { GeneratedBoxMetadata, SelectionId } from '@/lib/types'
@@ -178,14 +178,12 @@ export default function BoxContextMenu({
 
     const isBoxSelected = boxInfos && selectedBoxIds.includes(boxInfos.id)
 
-    const canCombine =
-        selectedBoxIds.length >= 2 &&
-        canCombineGridBoxes(
-            grid,
-            getGridBoxes(grid, wallHeight).filter((box) =>
-                selectedBoxIds.includes(box.id)
-            )
-        )
+    const selectedBoxes = getGridBoxes(grid, wallHeight).filter((box) =>
+        selectedBoxIds.includes(box.id)
+    )
+    const combineValidation = validateGridBoxCombination(grid, selectedBoxes)
+    const canAttemptCombine = selectedBoxes.length >= 2
+    const canCombine = combineValidation.valid
 
     if (selectedBoxIds.length === 0) {
         // if no boxes are selected, don't show the menu
@@ -288,23 +286,38 @@ export default function BoxContextMenu({
                         </div>
                     )}
 
-                    {canCombine && (
+                    {canAttemptCombine && (
                         <div
-                            className="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground"
+                            className={
+                                'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground' +
+                                (canCombine ? '' : ' text-destructive')
+                            }
                             onClick={() =>
                                 handleMenuItemClick('Combine Selected Boxes')
                             }
-                            title="Combine selected boxes"
+                            title={
+                                canCombine
+                                    ? 'Combine selected boxes'
+                                    : combineValidation.message
+                            }
                         >
                             <Combine className="mr-2 h-4 w-4" />
-                            Combine Selected Boxes
+                            {canCombine
+                                ? 'Combine Selected Boxes'
+                                : 'Cannot Combine Selection'}
                             <span className="ml-auto text-xs tracking-widest text-muted-foreground">
                                 C
                             </span>
                         </div>
                     )}
 
-                    {(canSplit || canCombine) && (
+                    {canAttemptCombine && !combineValidation.valid && (
+                        <p className="px-2 pb-1 text-xs text-destructive">
+                            {combineValidation.message}
+                        </p>
+                    )}
+
+                    {(canSplit || canAttemptCombine) && (
                         <div className="-mx-1 my-1 h-px bg-border" />
                     )}
 
@@ -338,20 +351,35 @@ export default function BoxContextMenu({
                         </span>
                     </div>
 
-                    {canCombine && (
+                    {canAttemptCombine && (
                         <div
-                            className="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground"
+                            className={
+                                'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground' +
+                                (canCombine ? '' : ' text-destructive')
+                            }
                             onClick={() =>
                                 handleMenuItemClick('Combine Selected Boxes')
                             }
-                            title="Combine selected boxes"
+                            title={
+                                canCombine
+                                    ? 'Combine selected boxes'
+                                    : combineValidation.message
+                            }
                         >
                             <Combine className="mr-2 h-4 w-4" />
-                            Combine Selected Boxes
+                            {canCombine
+                                ? 'Combine Selected Boxes'
+                                : 'Cannot Combine Selection'}
                             <span className="ml-auto text-xs tracking-widest text-muted-foreground">
                                 C
                             </span>
                         </div>
+                    )}
+
+                    {canAttemptCombine && !combineValidation.valid && (
+                        <p className="px-2 pb-1 text-xs text-destructive">
+                            {combineValidation.message}
+                        </p>
                     )}
 
                     <div className="-mx-1 my-1 h-px bg-border" />

--- a/hooks/useGridCommands.ts
+++ b/hooks/useGridCommands.ts
@@ -5,8 +5,10 @@ import {
     splitSelectedBoxes,
     toggleSelectedBoxesVisibility,
 } from '@/lib/gridCommands'
+import { getGridBoxes } from '@/lib/gridVisibility'
 import { useStore } from '@/lib/store'
 import { useCallback, useEffect, useMemo } from 'react'
+import { toast } from 'sonner'
 
 export interface GridCommands {
     clearSelection: () => void
@@ -26,15 +28,7 @@ export function useGridCommands(): GridCommands {
     }, [])
 
     const combineSelection = useCallback(() => {
-        const state = useStore.getState()
-        const grid = combineSelectedBoxes(
-            state.grid,
-            state.wallHeight,
-            state.selectedBoxIds
-        )
-        if (!grid) return
-        state.setGrid(grid)
-        state.setSelectedBoxIds([])
+        executeCombineSelection((message) => toast.error(message))
     }, [])
 
     const splitSelection = useCallback(() => {
@@ -71,22 +65,81 @@ export function useGridCommands(): GridCommands {
         ]
     )
 
-    useEffect(() => bindGridKeyboardShortcuts(window, commands), [commands])
+    useEffect(
+        () => bindGridKeyboardShortcuts(window, commands, getSelectedBoxCount),
+        [commands]
+    )
     return commands
+}
+
+export function executeCombineSelection(
+    reportError: (message: string) => void
+): boolean {
+    const state = useStore.getState()
+    const result = combineSelectedBoxes(
+        state.grid,
+        state.wallHeight,
+        state.selectedBoxIds
+    )
+    if (!result.combined) {
+        reportError(result.validation.message)
+        return false
+    }
+
+    state.setGrid(result.grid)
+    state.setSelectedBoxIds([])
+    return true
 }
 
 export function bindGridKeyboardShortcuts(
     target: KeyboardEventTarget,
-    commands: GridCommands
+    commands: GridCommands,
+    getSelectedBoxCount: () => number
 ): () => void {
     const onKeyDown: EventListener = (event) => {
-        const key = (event as KeyboardEvent).key
+        const keyboardEvent = event as KeyboardEvent
+        if (isEditableTarget(keyboardEvent.target)) return
+
+        const key = keyboardEvent.key
         if (key === 'Escape') commands.clearSelection()
-        if (key === 'c') commands.combineSelection()
+        if (key === 'c' && getSelectedBoxCount() >= 2) {
+            commands.combineSelection()
+        }
         if (key === 's') commands.splitSelection()
         if (key === 'h') commands.toggleSelectionVisibility()
     }
 
     target.addEventListener('keydown', onKeyDown)
     return () => target.removeEventListener('keydown', onKeyDown)
+}
+
+function getSelectedBoxCount(): number {
+    const state = useStore.getState()
+    return getGridBoxes(state.grid, state.wallHeight).filter((box) =>
+        state.selectedBoxIds.includes(box.id)
+    ).length
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+    if (!target || typeof target !== 'object') return false
+
+    const element = target as {
+        tagName?: string
+        isContentEditable?: boolean
+        closest?: (selector: string) => unknown
+        getAttribute?: (name: string) => string | null
+    }
+    const tagName = element.tagName?.toLowerCase()
+    return (
+        tagName === 'input' ||
+        tagName === 'textarea' ||
+        tagName === 'select' ||
+        element.isContentEditable === true ||
+        element.getAttribute?.('role') === 'textbox' ||
+        Boolean(
+            element.closest?.(
+                '[contenteditable]:not([contenteditable="false"])'
+            )
+        )
+    )
 }

--- a/lib/gridCombine.ts
+++ b/lib/gridCombine.ts
@@ -1,34 +1,107 @@
-import { getOutline } from '@/lib/lineHelper'
+import { getOutline, OutlineTopologyError } from '@/lib/lineHelper'
 import type { GeneratedBoxMetadata, Grid } from '@/lib/types'
 
 export type GridBoxSelection = Pick<GeneratedBoxMetadata, 'cells'>
+
+export type CombineValidationCode =
+    | 'too-few-boxes'
+    | 'empty-selection'
+    | 'out-of-bounds'
+    | 'disconnected'
+    | 'contains-hole'
+    | 'invalid-topology'
+
+export type CombineValidationResult =
+    | { valid: true }
+    | {
+          valid: false
+          code: CombineValidationCode
+          message: string
+      }
+
+export type CombineValidationFailure = Extract<
+    CombineValidationResult,
+    { valid: false }
+>
+
+export type CombineMutationResult =
+    | { combined: true }
+    | { combined: false; validation: CombineValidationFailure }
+
+type CombineAnalysis =
+    { valid: true; selectedCells: Set<string> } | CombineValidationFailure
+
+export function validateGridBoxCombination(
+    grid: Grid,
+    boxes: GridBoxSelection[]
+): CombineValidationResult {
+    const analysis = analyzeGridBoxCombination(grid, boxes)
+    return analysis.valid ? { valid: true } : analysis
+}
+
+function analyzeGridBoxCombination(
+    grid: Grid,
+    boxes: GridBoxSelection[]
+): CombineAnalysis {
+    if (boxes.length < 2) {
+        return invalid('too-few-boxes', 'Select at least two boxes to combine.')
+    }
+
+    const selectedCells = selectedCellKeys(boxes)
+    if (selectedCells.size === 0) {
+        return invalid(
+            'empty-selection',
+            'The selected boxes contain no cells.'
+        )
+    }
+
+    for (const key of selectedCells) {
+        const { x, z } = parseCellKey(key)
+        if (!grid[z]?.[x]) {
+            return invalid(
+                'out-of-bounds',
+                'The selection contains a cell outside the grid.'
+            )
+        }
+    }
+
+    const nextGroup = getNextAvailableGroupId(grid)
+    const candidate = grid.map((row) => row.map((cell) => ({ ...cell })))
+    selectedCells.forEach((key) => {
+        const { x, z } = parseCellKey(key)
+        candidate[z][x].group = nextGroup
+    })
+
+    try {
+        getOutline(candidate, nextGroup)
+        return { valid: true, selectedCells }
+    } catch (error) {
+        if (error instanceof OutlineTopologyError) {
+            if (error.code === 'disconnected') {
+                return invalid(
+                    'disconnected',
+                    'Selected boxes must share an edge to form one connected shape.'
+                )
+            }
+            if (error.code === 'contains-hole') {
+                return invalid(
+                    'contains-hole',
+                    'Selected boxes cannot enclose a hole.'
+                )
+            }
+        }
+        return invalid(
+            'invalid-topology',
+            'Selected boxes form an unsupported shape.'
+        )
+    }
+}
 
 export function canCombineGridBoxes(
     grid: Grid,
     boxes: GridBoxSelection[]
 ): boolean {
-    if (boxes.length < 2 || grid.length === 0 || grid[0].length === 0) {
-        return false
-    }
-
-    const nextGroup = getNextAvailableGroupId(grid)
-    const candidate = grid.map((row) => row.map((cell) => ({ ...cell })))
-    const selectedCells = selectedCellKeys(boxes)
-
-    if (selectedCells.size === 0) return false
-
-    for (const key of selectedCells) {
-        const [x, z] = key.split(',').map(Number)
-        if (!candidate[z]?.[x]) return false
-        candidate[z][x].group = nextGroup
-    }
-
-    try {
-        getOutline(candidate, nextGroup)
-        return true
-    } catch {
-        return false
-    }
+    return validateGridBoxCombination(grid, boxes).valid
 }
 
 export function combineGridBoxes(
@@ -36,13 +109,22 @@ export function combineGridBoxes(
     boxes: GridBoxSelection[],
     groupId: number
 ): boolean {
-    if (!canCombineGridBoxes(grid, boxes)) return false
+    return tryCombineGridBoxes(grid, boxes, groupId).combined
+}
 
-    selectedCellKeys(boxes).forEach((key) => {
-        const [x, z] = key.split(',').map(Number)
+export function tryCombineGridBoxes(
+    grid: Grid,
+    boxes: GridBoxSelection[],
+    groupId: number
+): CombineMutationResult {
+    const analysis = analyzeGridBoxCombination(grid, boxes)
+    if (!analysis.valid) return { combined: false, validation: analysis }
+
+    analysis.selectedCells.forEach((key) => {
+        const { x, z } = parseCellKey(key)
         grid[z][x].group = groupId
     })
-    return true
+    return { combined: true }
 }
 
 export function getNextAvailableGroupId(grid: Grid): number {
@@ -64,4 +146,16 @@ function getSelectionCells(
     box: GridBoxSelection
 ): Array<{ x: number; z: number }> {
     return box.cells
+}
+
+function parseCellKey(key: string): { x: number; z: number } {
+    const [x, z] = key.split(',').map(Number)
+    return { x, z }
+}
+
+function invalid(
+    code: CombineValidationCode,
+    message: string
+): CombineValidationFailure {
+    return { valid: false, code, message }
 }

--- a/lib/gridCommands.ts
+++ b/lib/gridCommands.ts
@@ -1,4 +1,8 @@
-import { combineGridBoxes, getNextAvailableGroupId } from '@/lib/gridCombine'
+import {
+    getNextAvailableGroupId,
+    tryCombineGridBoxes,
+    type CombineValidationFailure,
+} from '@/lib/gridCombine'
 import {
     getBoxById,
     getGridBoxes,
@@ -11,15 +15,17 @@ export function combineSelectedBoxes(
     grid: Grid,
     wallHeight: number,
     selectedIds: SelectionId[]
-): Grid | null {
+):
+    | { combined: true; grid: Grid }
+    | { combined: false; validation: CombineValidationFailure } {
     const selectedBoxes = getGridBoxes(grid, wallHeight).filter((box) =>
         selectedIds.includes(box.id)
     )
-    if (selectedBoxes.length < 2) return null
-
     const nextGrid = cloneGrid(grid)
     const newId = getNextAvailableGroupId(nextGrid)
-    return combineGridBoxes(nextGrid, selectedBoxes, newId) ? nextGrid : null
+    const result = tryCombineGridBoxes(nextGrid, selectedBoxes, newId)
+    if (!result.combined) return result
+    return { combined: true, grid: nextGrid }
 }
 
 export function splitSelectedBoxes(

--- a/lib/lineHelper.ts
+++ b/lib/lineHelper.ts
@@ -3,6 +3,23 @@ import * as THREE from 'three'
 
 type Segment = { a: THREE.Vector2; b: THREE.Vector2 }
 
+export type OutlineTopologyCode =
+    | 'disconnected'
+    | 'self-intersection'
+    | 'incomplete-boundary'
+    | 'contains-hole'
+
+export class OutlineTopologyError extends Error {
+    constructor(
+        readonly groupId: number,
+        readonly code: OutlineTopologyCode,
+        message: string
+    ) {
+        super(`Cannot build outline for group ${groupId}: ${message}.`)
+        this.name = 'OutlineTopologyError'
+    }
+}
+
 export function getOutline(grid: Grid, groupId: number): THREE.Vector2[] {
     if (grid.length === 0 || grid[0].length === 0) {
         throw new Error('Cannot build an outline for an empty grid.')
@@ -74,7 +91,7 @@ export function getOutline(grid: Grid, groupId: number): THREE.Vector2[] {
     }
 
     if (!cellsAreConnected(cells)) {
-        throw outlineError(groupId, 'region is disconnected')
+        throw outlineError(groupId, 'disconnected')
     }
 
     const outgoing = new Map<string, number[]>()
@@ -89,10 +106,10 @@ export function getOutline(grid: Grid, groupId: number): THREE.Vector2[] {
         const outgoingCount = outgoing.get(vertex)?.length ?? 0
         const incomingCount = incoming.get(vertex)?.length ?? 0
         if (outgoingCount > 1 || incomingCount > 1) {
-            throw outlineError(groupId, 'boundary self-intersects')
+            throw outlineError(groupId, 'self-intersection')
         }
         if (outgoingCount !== 1 || incomingCount !== 1) {
-            throw outlineError(groupId, 'boundary loop could not be completed')
+            throw outlineError(groupId, 'incomplete-boundary')
         }
     }
 
@@ -115,16 +132,16 @@ export function getOutline(grid: Grid, groupId: number): THREE.Vector2[] {
 
         const next = outgoing.get(nextKey)
         if (!next || next.length !== 1 || used.has(next[0])) {
-            throw outlineError(groupId, 'boundary loop could not be completed')
+            throw outlineError(groupId, 'incomplete-boundary')
         }
         currentIndex = next[0]
     }
 
     if (!closed) {
-        throw outlineError(groupId, 'boundary loop could not be completed')
+        throw outlineError(groupId, 'incomplete-boundary')
     }
     if (used.size !== segments.length) {
-        throw outlineError(groupId, 'region contains a hole')
+        throw outlineError(groupId, 'contains-hole')
     }
     // Positive dimensions make both coordinate maps strictly increasing, so
     // the validated grid-space topology cannot gain intersections here.
@@ -141,8 +158,17 @@ function addEdge(map: Map<string, number[]>, key: string, index: number): void {
     map.set(key, edges)
 }
 
-function outlineError(groupId: number, reason: string): Error {
-    return new Error(`Cannot build outline for group ${groupId}: ${reason}.`)
+function outlineError(
+    groupId: number,
+    code: OutlineTopologyCode
+): OutlineTopologyError {
+    const messages: Record<OutlineTopologyCode, string> = {
+        disconnected: 'region is disconnected',
+        'self-intersection': 'boundary self-intersects',
+        'incomplete-boundary': 'boundary loop could not be completed',
+        'contains-hole': 'region contains a hole',
+    }
+    return new OutlineTopologyError(groupId, code, messages[code])
 }
 
 function cellsAreConnected(cells: THREE.Vector2[]): boolean {

--- a/tests/geometry.test.ts
+++ b/tests/geometry.test.ts
@@ -3,6 +3,7 @@ import {
     canCombineGridBoxes,
     combineGridBoxes,
     getNextAvailableGroupId,
+    validateGridBoxCombination,
 } from '@/lib/gridCombine'
 import { gridMatchesLayout, resizeGrid } from '@/lib/gridHelper'
 import {
@@ -10,7 +11,11 @@ import {
     isGridBoxVisible,
     setGridBoxVisible,
 } from '@/lib/gridVisibility'
-import { getOutline } from '@/lib/lineHelper'
+import {
+    getOutline,
+    OutlineTopologyError,
+    type OutlineTopologyCode,
+} from '@/lib/lineHelper'
 import { sanitizeModelParameters } from '@/lib/parameterValidation'
 import { useStore } from '@/lib/store'
 import { Grid } from '@/lib/types'
@@ -26,6 +31,19 @@ function signedArea(outline: ReturnType<typeof getOutline>): number {
         const next = outline[(index + 1) % outline.length]
         return sum + point.x * next.y - next.x * point.y
     }, 0)
+}
+
+function expectTopologyError(
+    action: () => unknown,
+    code: OutlineTopologyCode
+): void {
+    try {
+        action()
+        throw new Error('Expected a topology error')
+    } catch (error) {
+        expect(error).toBeInstanceOf(OutlineTopologyError)
+        expect((error as OutlineTopologyError).code).toBe(code)
+    }
 }
 
 function meshes(object: THREE.Object3D): THREE.Mesh[] {
@@ -234,9 +252,7 @@ describe('geometry outlines', () => {
             ],
         ]
 
-        expect(() => getOutline(grid, 9)).toThrow(
-            'Cannot build outline for group 9: region is disconnected.'
-        )
+        expectTopologyError(() => getOutline(grid, 9), 'disconnected')
     })
 
     it('rejects holed groups that need multiple outline loops', () => {
@@ -258,9 +274,7 @@ describe('geometry outlines', () => {
             ],
         ]
 
-        expect(() => getOutline(grid, 8)).toThrow(
-            'Cannot build outline for group 8: region contains a hole.'
-        )
+        expectTopologyError(() => getOutline(grid, 8), 'contains-hole')
     })
 
     it('rejects boundaries that touch and self-intersect at a vertex', () => {
@@ -282,9 +296,7 @@ describe('geometry outlines', () => {
             ],
         ]
 
-        expect(() => getOutline(grid, 5)).toThrow(
-            'Cannot build outline for group 5: boundary self-intersects.'
-        )
+        expectTopologyError(() => getOutline(grid, 5), 'self-intersection')
     })
 
     it('rejects malformed grids explicitly', () => {
@@ -479,9 +491,11 @@ describe('box generation', () => {
             ],
         ]
 
-        expect(() =>
-            generateCustomBox(grid, generationOptions({ cornerRadius: 0 }))
-        ).toThrow('Cannot build outline for group 6: region is disconnected.')
+        expectTopologyError(
+            () =>
+                generateCustomBox(grid, generationOptions({ cornerRadius: 0 })),
+            'disconnected'
+        )
     })
 
     it('makes every generation option observable in the output', () => {
@@ -585,8 +599,31 @@ describe('grid combine policy', () => {
         const boxes = [{ cells: [{ x: 0, z: 0 }] }, { cells: [{ x: 2, z: 0 }] }]
 
         expect(canCombineGridBoxes(grid, boxes)).toBe(false)
+        expect(validateGridBoxCombination(grid, boxes)).toMatchObject({
+            valid: false,
+            code: 'disconnected',
+        })
         expect(combineGridBoxes(grid, boxes, 1)).toBe(false)
         expect(grid[0].map((cell) => cell.group)).toEqual([0, 0, 0])
+    })
+
+    it('does not treat diagonal corner contact as connected', () => {
+        const grid: Grid = [
+            [
+                { group: 0, width: 20, depth: 20 },
+                { group: 0, width: 20, depth: 20 },
+            ],
+            [
+                { group: 0, width: 20, depth: 20 },
+                { group: 0, width: 20, depth: 20 },
+            ],
+        ]
+        const boxes = [{ cells: [{ x: 0, z: 0 }] }, { cells: [{ x: 1, z: 1 }] }]
+
+        expect(validateGridBoxCombination(grid, boxes)).toMatchObject({
+            valid: false,
+            code: 'disconnected',
+        })
     })
 
     it('rejects holed selected boxes without mutating the grid', () => {
@@ -619,8 +656,32 @@ describe('grid combine policy', () => {
         ]
 
         expect(canCombineGridBoxes(grid, boxes)).toBe(false)
+        expect(validateGridBoxCombination(grid, boxes)).toMatchObject({
+            valid: false,
+            code: 'contains-hole',
+        })
         expect(combineGridBoxes(grid, boxes, 1)).toBe(false)
         expect(grid.flat().map((cell) => cell.group)).toEqual(Array(9).fill(0))
+    })
+
+    it('accepts cells connected through an L-shaped edge path', () => {
+        const grid: Grid = [
+            [
+                { group: 0, width: 20, depth: 20 },
+                { group: 0, width: 20, depth: 20 },
+            ],
+            [
+                { group: 0, width: 20, depth: 20 },
+                { group: 0, width: 20, depth: 20 },
+            ],
+        ]
+        const boxes = [
+            { cells: [{ x: 0, z: 0 }] },
+            { cells: [{ x: 1, z: 0 }] },
+            { cells: [{ x: 0, z: 1 }] },
+        ]
+
+        expect(validateGridBoxCombination(grid, boxes)).toEqual({ valid: true })
     })
 })
 

--- a/tests/gridCommands.test.ts
+++ b/tests/gridCommands.test.ts
@@ -1,5 +1,6 @@
 import {
     bindGridKeyboardShortcuts,
+    executeCombineSelection,
     type GridCommands,
 } from '@/hooks/useGridCommands'
 import {
@@ -7,8 +8,14 @@ import {
     splitSelectedBoxes,
     toggleSelectedBoxesVisibility,
 } from '@/lib/gridCommands'
+import * as lineHelper from '@/lib/lineHelper'
+import { useStore } from '@/lib/store'
 import type { Grid } from '@/lib/types'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+afterEach(() => {
+    useStore.setState({ grid: [], selectedBoxIds: [] })
+})
 
 describe('grid commands', () => {
     it('applies combine, split, and visibility changes without mutating input', () => {
@@ -22,15 +29,57 @@ describe('grid commands', () => {
             'cell:0:0',
             'cell:1:0',
         ])
-        expect(combined?.[0].map((cell) => cell.group)).toEqual([1, 1])
+        expect(combined.combined).toBe(true)
+        if (!combined.combined) throw new Error('Expected boxes to combine')
+        expect(combined.grid[0].map((cell) => cell.group)).toEqual([1, 1])
         expect(grid[0].map((cell) => cell.group)).toEqual([0, 0])
 
-        const split = splitSelectedBoxes(combined!, ['group:1'])
+        const split = splitSelectedBoxes(combined.grid, ['group:1'])
         expect(split?.[0].map((cell) => cell.group)).toEqual([0, 0])
 
         const hidden = toggleSelectedBoxesVisibility(grid, ['cell:0:0'])
         expect(hidden?.[0][0].visibility).toBe('hidden')
         expect(grid[0][0].visibility).toBeUndefined()
+    })
+
+    it('returns a clear failure without mutating disconnected selections', () => {
+        const grid: Grid = [
+            [
+                { group: 0, width: 20, depth: 20 },
+                { group: 0, width: 20, depth: 20 },
+                { group: 0, width: 20, depth: 20 },
+            ],
+        ]
+
+        const result = combineSelectedBoxes(grid, 30, ['cell:0:0', 'cell:2:0'])
+
+        expect(result).toEqual({
+            combined: false,
+            validation: {
+                valid: false,
+                code: 'disconnected',
+                message:
+                    'Selected boxes must share an edge to form one connected shape.',
+            },
+        })
+        expect(grid[0].map((cell) => cell.group)).toEqual([0, 0, 0])
+    })
+
+    it('performs one topology analysis for a successful combine command', () => {
+        const outline = vi.spyOn(lineHelper, 'getOutline')
+        const grid: Grid = [
+            [
+                { group: 0, width: 20, depth: 20 },
+                { group: 0, width: 20, depth: 20 },
+            ],
+        ]
+
+        const result = combineSelectedBoxes(grid, 30, ['cell:0:0', 'cell:1:0'])
+
+        expect(result.combined).toBe(true)
+        expect(outline).toHaveBeenCalledOnce()
+        expect(grid[0].map((cell) => cell.group)).toEqual([0, 0])
+        outline.mockRestore()
     })
 
     it('registers keyboard mapping once and removes the same listener', () => {
@@ -48,7 +97,7 @@ describe('grid commands', () => {
             toggleSelectionVisibility: vi.fn(),
         }
 
-        const unbind = bindGridKeyboardShortcuts(target, commands)
+        const unbind = bindGridKeyboardShortcuts(target, commands, () => 2)
         const keydown = listener as unknown as (event: KeyboardEvent) => void
         keydown({ key: 'Escape' } as KeyboardEvent)
         keydown({ key: 'c' } as KeyboardEvent)
@@ -66,4 +115,106 @@ describe('grid commands', () => {
             listener
         )
     })
+
+    it.each([0, 1])(
+        'ignores the combine shortcut with %i selected boxes',
+        (selectedBoxCount) => {
+            let listener: EventListener | null = null
+            const target = {
+                addEventListener: vi.fn(
+                    (_type, nextListener: EventListener) => {
+                        listener = nextListener
+                    }
+                ),
+                removeEventListener: vi.fn(),
+            }
+            const commands = stubCommands()
+            bindGridKeyboardShortcuts(target, commands, () => selectedBoxCount)
+
+            const keydown = listener as unknown as (
+                event: KeyboardEvent
+            ) => void
+            keydown({ key: 'c', target: null } as KeyboardEvent)
+
+            expect(commands.combineSelection).not.toHaveBeenCalled()
+        }
+    )
+
+    it('dispatches combine with two selected boxes so topology feedback can run', () => {
+        let listener: EventListener | null = null
+        const target = {
+            addEventListener: vi.fn((_type, nextListener: EventListener) => {
+                listener = nextListener
+            }),
+            removeEventListener: vi.fn(),
+        }
+        const commands = stubCommands()
+        bindGridKeyboardShortcuts(target, commands, () => 2)
+
+        const keydown = listener as unknown as (event: KeyboardEvent) => void
+        keydown({ key: 'c', target: null } as KeyboardEvent)
+
+        expect(commands.combineSelection).toHaveBeenCalledOnce()
+    })
+
+    it('reports invalid topology for two boxes without changing selection', () => {
+        const grid: Grid = [
+            [
+                { group: 0, width: 20, depth: 20 },
+                { group: 0, width: 20, depth: 20 },
+                { group: 0, width: 20, depth: 20 },
+            ],
+        ]
+        useStore.setState({
+            grid,
+            wallHeight: 30,
+            selectedBoxIds: ['cell:0:0', 'cell:2:0'],
+        })
+        const reportError = vi.fn()
+
+        expect(executeCombineSelection(reportError)).toBe(false)
+
+        expect(reportError).toHaveBeenCalledWith(
+            'Selected boxes must share an edge to form one connected shape.'
+        )
+        expect(useStore.getState().grid).toBe(grid)
+        expect(useStore.getState().selectedBoxIds).toEqual([
+            'cell:0:0',
+            'cell:2:0',
+        ])
+    })
+
+    it.each([
+        { tagName: 'INPUT', isContentEditable: false },
+        { tagName: 'TEXTAREA', isContentEditable: false },
+        { tagName: 'SELECT', isContentEditable: false },
+        { tagName: 'DIV', isContentEditable: true },
+    ])('ignores shortcuts from editable targets', (editableTarget) => {
+        let listener: EventListener | null = null
+        const target = {
+            addEventListener: vi.fn((_type, nextListener: EventListener) => {
+                listener = nextListener
+            }),
+            removeEventListener: vi.fn(),
+        }
+        const commands = stubCommands()
+        bindGridKeyboardShortcuts(target, commands, () => 2)
+
+        const keydown = listener as unknown as (event: KeyboardEvent) => void
+        keydown({
+            key: 'c',
+            target: editableTarget,
+        } as unknown as KeyboardEvent)
+
+        expect(commands.combineSelection).not.toHaveBeenCalled()
+    })
 })
+
+function stubCommands(): GridCommands {
+    return {
+        clearSelection: vi.fn(),
+        combineSelection: vi.fn(),
+        splitSelection: vi.fn(),
+        toggleSelectionVisibility: vi.fn(),
+    }
+}


### PR DESCRIPTION
## What changed

- Added explicit topology validation before combining selected boxes.
- Rejects disconnected, diagonal-only, holed, empty, undersized, out-of-bounds, and unsupported selections without mutating the grid or clearing selection.
- Added stable typed topology error codes in the outline subsystem so domain validation no longer parses human-readable exception messages.
- Added a safe combine result API that performs one authoritative outline analysis and one mutation pass.
- Added clear toolbar and context-menu explanations plus toast feedback for invalid combine attempts.
- Updated the global keyboard handler to ignore editable targets and skip the `C` shortcut when fewer than two current boxes are selected.
- Added regression coverage for topology codes, immutability, diagonal connectivity, invalid feedback, editable targets, zero/one selection, and single-analysis execution.

## Why

TW-206 requires combinations to be rejected before invalid or surprising geometry can be generated. The previous boolean-only validation relied on outline exceptions, provided no user-facing reason, and could silently ignore keyboard attempts.

The first implementation also introduced duplicate full-grid topology analysis and allowed the global `C` shortcut to show irrelevant errors while users typed in controls. This revision centralizes topology ownership in the outline subsystem, preserves a safe public mutation API, and keeps invalid feedback limited to real combine attempts.

## Impact

Users now receive a clear explanation when selected boxes do not form a supported edge-connected shape. Valid combines preserve existing behavior, while invalid attempts leave both the grid and current selection unchanged. Successful combine commands avoid repeated synchronous topology work.

## Validation

- `corepack npm run lint`
- `corepack npm exec tsc -- --noEmit`
- `corepack npm test` — 57 tests passed
- `corepack npm run build` — production build passed

Toolchain: Node 24 with npm 11.18.0.