### PR TITLE
TW-224 Validate smallest possible box

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import HiddenBoxesDisplay from '@/components/HiddenBoxesDisplay'
 import { useGridCommands } from '@/hooks/useGridCommands'
 import { useGridLayout } from '@/hooks/useGridLayout'
 import { useSceneView } from '@/hooks/useSceneView'
+import { getMinimumBoxSize } from '@/lib/parameterValidation'
 import type { ScenePointerSelection } from '@/lib/sceneViewAdapter'
 import { useStore } from '@/lib/store'
 import { useCallback } from 'react'
@@ -13,12 +14,17 @@ import { useCallback } from 'react'
 export default function Home() {
     const state = useStore()
     const commands = useGridCommands()
+    const minBoxSize = getMinimumBoxSize(
+        state.wallThickness,
+        state.cornerRadius
+    )
     const grid = useGridLayout({
         grid: state.grid,
         totalWidth: state.totalWidth,
         totalDepth: state.totalDepth,
         maxBoxWidth: state.maxBoxWidth,
         maxBoxDepth: state.maxBoxDepth,
+        minBoxSize,
         setGrid: state.setGrid,
     })
 

--- a/components/ConfigSidebar/ModelSettings.tsx
+++ b/components/ConfigSidebar/ModelSettings.tsx
@@ -5,6 +5,7 @@ import {
     CollapsibleTrigger,
 } from '@/components/ui/collapsible'
 import { parameters } from '@/lib/defaults'
+import { getMinimumBoxSize } from '@/lib/parameterValidation'
 import { useStore } from '@/lib/store'
 import { cn } from '@/lib/utils'
 import { ChevronsDown } from 'lucide-react'
@@ -16,6 +17,10 @@ export default function ModelSettings() {
     const store = useStore()
     const [generalCollapsable, setGeneralCollapsable] = useState(true)
     const [gridCollapsable, setGridCollapsable] = useState(true)
+    const minBoxSize = getMinimumBoxSize(
+        store.wallThickness,
+        store.cornerRadius
+    )
     return (
         <>
             <Collapsible
@@ -40,7 +45,7 @@ export default function ModelSettings() {
                         label="Total Width (mm)"
                         value={store.totalWidth}
                         setValue={store.setTotalWidth}
-                        min={parameters.totalWidth.min}
+                        min={Math.max(parameters.totalWidth.min, minBoxSize)}
                         max={parameters.totalWidth.max}
                         step={parameters.totalWidth.steps}
                     />
@@ -49,7 +54,7 @@ export default function ModelSettings() {
                         label="Total Depth (mm)"
                         value={store.totalDepth}
                         setValue={store.setTotalDepth}
-                        min={parameters.totalDepth.min}
+                        min={Math.max(parameters.totalDepth.min, minBoxSize)}
                         max={parameters.totalDepth.max}
                         step={parameters.totalDepth.steps}
                     />
@@ -112,7 +117,7 @@ export default function ModelSettings() {
                         label="Max Box Width (mm)"
                         value={store.maxBoxWidth}
                         setValue={store.setMaxBoxWidth}
-                        min={parameters.maxBoxWidth.min}
+                        min={Math.max(parameters.maxBoxWidth.min, minBoxSize)}
                         max={parameters.maxBoxWidth.max}
                         step={parameters.maxBoxWidth.steps}
                     />
@@ -122,7 +127,7 @@ export default function ModelSettings() {
                         label="Max Box Depth (mm)"
                         value={store.maxBoxDepth}
                         setValue={store.setMaxBoxDepth}
-                        min={parameters.maxBoxDepth.min}
+                        min={Math.max(parameters.maxBoxDepth.min, minBoxSize)}
                         max={parameters.maxBoxDepth.max}
                         step={parameters.maxBoxDepth.steps}
                     />

--- a/hooks/useGridLayout.ts
+++ b/hooks/useGridLayout.ts
@@ -10,6 +10,7 @@ interface GridLayoutOptions {
     totalDepth: number
     maxBoxWidth: number
     maxBoxDepth: number
+    minBoxSize: number
     setGrid: (grid: Grid) => void
 }
 
@@ -19,6 +20,7 @@ export function useGridLayout({
     totalDepth,
     maxBoxWidth,
     maxBoxDepth,
+    minBoxSize,
     setGrid,
 }: GridLayoutOptions): Grid {
     const resolvedGrid = useMemo(() => {
@@ -28,7 +30,8 @@ export function useGridLayout({
                 totalWidth,
                 totalDepth,
                 maxBoxWidth,
-                maxBoxDepth
+                maxBoxDepth,
+                minBoxSize
             )
         ) {
             return grid
@@ -38,9 +41,10 @@ export function useGridLayout({
             totalWidth,
             totalDepth,
             maxBoxWidth,
-            maxBoxDepth
+            maxBoxDepth,
+            minBoxSize
         )
-    }, [grid, totalWidth, totalDepth, maxBoxWidth, maxBoxDepth])
+    }, [grid, totalWidth, totalDepth, maxBoxWidth, maxBoxDepth, minBoxSize])
 
     useEffect(() => {
         if (resolvedGrid !== grid) setGrid(resolvedGrid)

--- a/lib/gridHelper.ts
+++ b/lib/gridHelper.ts
@@ -6,10 +6,11 @@ export function resizeGrid(
     totalWidth: number,
     totalDepth: number,
     maxBoxWidth: number,
-    maxBoxDepth: number
+    maxBoxDepth: number,
+    minBoxSize = 0
 ): Grid {
-    const widths = segmentSizes(totalWidth, maxBoxWidth)
-    const depths = segmentSizes(totalDepth, maxBoxDepth)
+    const widths = segmentSizes(totalWidth, maxBoxWidth, minBoxSize)
+    const depths = segmentSizes(totalDepth, maxBoxDepth, minBoxSize)
 
     return depths.map((depth, rowIdx) =>
         widths.map((width, colIdx) => {
@@ -31,10 +32,11 @@ export function gridMatchesLayout(
     totalWidth: number,
     totalDepth: number,
     maxBoxWidth: number,
-    maxBoxDepth: number
+    maxBoxDepth: number,
+    minBoxSize = 0
 ): boolean {
-    const widths = segmentSizes(totalWidth, maxBoxWidth)
-    const depths = segmentSizes(totalDepth, maxBoxDepth)
+    const widths = segmentSizes(totalWidth, maxBoxWidth, minBoxSize)
+    const depths = segmentSizes(totalDepth, maxBoxDepth, minBoxSize)
 
     if (grid.length !== depths.length) return false
     if (grid.length === 0) return widths.length === 0

--- a/lib/gridHelper.ts
+++ b/lib/gridHelper.ts
@@ -1,3 +1,4 @@
+import { segmentSizes } from '@/lib/gridSizing'
 import { Grid } from '@/lib/types'
 
 export function resizeGrid(
@@ -44,15 +45,4 @@ export function gridMatchesLayout(
         widths.every((width, colIdx) => grid[0][colIdx].width === width) &&
         depths.every((depth, rowIdx) => grid[rowIdx][0].depth === depth)
     )
-}
-
-function segmentSizes(total: number, maxSize: number): number[] {
-    if (!Number.isFinite(total) || !Number.isFinite(maxSize)) return [1]
-    if (total <= 0 || maxSize <= 0) return [1]
-
-    const fullCount = Math.floor(total / maxSize)
-    const remainder = total - fullCount * maxSize
-    const segments = Array(fullCount).fill(maxSize)
-    if (remainder > 0) segments.push(remainder)
-    return segments
 }

--- a/lib/gridSizing.ts
+++ b/lib/gridSizing.ts
@@ -1,0 +1,14 @@
+export const dimensionTolerance = 1e-9
+
+export function segmentSizes(total: number, maxSize: number): number[] {
+    if (!Number.isFinite(total) || !Number.isFinite(maxSize)) return [1]
+    if (total <= 0 || maxSize <= 0) return [1]
+
+    const segmentCount = Math.max(
+        1,
+        Math.ceil(total / maxSize - dimensionTolerance)
+    )
+    const segments = Array(Math.max(0, segmentCount - 1)).fill(maxSize)
+    segments.push(total - maxSize * (segmentCount - 1))
+    return segments
+}

--- a/lib/gridSizing.ts
+++ b/lib/gridSizing.ts
@@ -1,3 +1,4 @@
+/** Floating-point tolerance in millimetres. */
 export const dimensionTolerance = 1e-9
 
 export function segmentSizes(
@@ -10,13 +11,13 @@ export function segmentSizes(
 
     const segmentCount = Math.max(
         1,
-        Math.ceil(total / maxSize - dimensionTolerance)
+        Math.ceil((total - dimensionTolerance / 2) / maxSize)
     )
     const segments = Array(Math.max(0, segmentCount - 1)).fill(maxSize)
     segments.push(total - maxSize * (segmentCount - 1))
 
     const lastSegment = segments[segments.length - 1]
-    if (lastSegment + dimensionTolerance >= minSize) return segments
+    if (lastSegment >= minSize) return segments
 
     const balancedSize = total / segmentCount
     const balancedSegments = Array(Math.max(0, segmentCount - 1)).fill(

--- a/lib/gridSizing.ts
+++ b/lib/gridSizing.ts
@@ -1,6 +1,10 @@
 export const dimensionTolerance = 1e-9
 
-export function segmentSizes(total: number, maxSize: number): number[] {
+export function segmentSizes(
+    total: number,
+    maxSize: number,
+    minSize = 0
+): number[] {
     if (!Number.isFinite(total) || !Number.isFinite(maxSize)) return [1]
     if (total <= 0 || maxSize <= 0) return [1]
 
@@ -10,5 +14,14 @@ export function segmentSizes(total: number, maxSize: number): number[] {
     )
     const segments = Array(Math.max(0, segmentCount - 1)).fill(maxSize)
     segments.push(total - maxSize * (segmentCount - 1))
-    return segments
+
+    const lastSegment = segments[segments.length - 1]
+    if (lastSegment + dimensionTolerance >= minSize) return segments
+
+    const balancedSize = total / segmentCount
+    const balancedSegments = Array(Math.max(0, segmentCount - 1)).fill(
+        balancedSize
+    )
+    balancedSegments.push(total - balancedSize * (segmentCount - 1))
+    return balancedSegments
 }

--- a/lib/parameterValidation.ts
+++ b/lib/parameterValidation.ts
@@ -1,4 +1,5 @@
 import { parameters } from '@/lib/defaults'
+import { dimensionTolerance, segmentSizes } from '@/lib/gridSizing'
 import type { StoreState } from '@/lib/types'
 
 export type ModelParameters = Pick<
@@ -12,62 +13,62 @@ export type ModelParameters = Pick<
     | 'maxBoxDepth'
 >
 
-const minClearance = 0.1
+export const minBoxClearance = 1
 
 export function sanitizeModelParameters(
     values: Partial<ModelParameters>,
     fallback: ModelParameters = defaultModelParameters
 ): ModelParameters {
+    const wallThickness = clampFinite(
+        values.wallThickness,
+        fallback.wallThickness,
+        parameters.wallThickness.min,
+        parameters.wallThickness.max
+    )
+    const cornerRadius = clampFinite(
+        values.cornerRadius,
+        fallback.cornerRadius,
+        parameters.cornerRadius.min,
+        parameters.cornerRadius.max
+    )
+    const minBoxSize = getMinimumBoxSize(wallThickness, cornerRadius)
     const totalWidth = clampFinite(
         values.totalWidth,
         fallback.totalWidth,
-        parameters.totalWidth.min,
+        Math.max(parameters.totalWidth.min, minBoxSize),
         parameters.totalWidth.max
     )
     const totalDepth = clampFinite(
         values.totalDepth,
         fallback.totalDepth,
-        parameters.totalDepth.min,
+        Math.max(parameters.totalDepth.min, minBoxSize),
         parameters.totalDepth.max
     )
-    const maxBoxWidth = clampFinite(
-        values.maxBoxWidth,
-        fallback.maxBoxWidth,
-        parameters.maxBoxWidth.min,
-        parameters.maxBoxWidth.max
+    const maxBoxWidth = extendMaxBoxSize(
+        totalWidth,
+        clampFinite(
+            values.maxBoxWidth,
+            fallback.maxBoxWidth,
+            Math.max(parameters.maxBoxWidth.min, minBoxSize),
+            parameters.maxBoxWidth.max
+        ),
+        minBoxSize
     )
-    const maxBoxDepth = clampFinite(
-        values.maxBoxDepth,
-        fallback.maxBoxDepth,
-        parameters.maxBoxDepth.min,
-        parameters.maxBoxDepth.max
+    const maxBoxDepth = extendMaxBoxSize(
+        totalDepth,
+        clampFinite(
+            values.maxBoxDepth,
+            fallback.maxBoxDepth,
+            Math.max(parameters.maxBoxDepth.min, minBoxSize),
+            parameters.maxBoxDepth.max
+        ),
+        minBoxSize
     )
     const wallHeight = clampFinite(
         values.wallHeight,
         fallback.wallHeight,
         parameters.wallHeight.min,
         parameters.wallHeight.max
-    )
-
-    const minBoxDimension = Math.min(
-        minSegmentSize(totalWidth, maxBoxWidth),
-        minSegmentSize(totalDepth, maxBoxDepth)
-    )
-    const maxWallThickness = Math.max(
-        parameters.wallThickness.min,
-        minBoxDimension / 2 - minClearance
-    )
-    const wallThickness = clampFinite(
-        values.wallThickness,
-        fallback.wallThickness,
-        parameters.wallThickness.min,
-        Math.min(parameters.wallThickness.max, maxWallThickness)
-    )
-    const cornerRadius = clampFinite(
-        values.cornerRadius,
-        fallback.cornerRadius,
-        parameters.cornerRadius.min,
-        Math.min(parameters.cornerRadius.max, minBoxDimension / 2)
     )
 
     return {
@@ -79,6 +80,20 @@ export function sanitizeModelParameters(
         maxBoxWidth,
         maxBoxDepth,
     }
+}
+
+export function getMinimumBoxSize(
+    wallThickness: number,
+    cornerRadius: number
+): number {
+    const safeWallThickness =
+        Number.isFinite(wallThickness) && wallThickness > 0 ? wallThickness : 0
+    const safeCornerRadius =
+        Number.isFinite(cornerRadius) && cornerRadius > 0 ? cornerRadius : 0
+
+    return roundDimension(
+        safeWallThickness * 2 + safeCornerRadius * 2 + minBoxClearance
+    )
 }
 
 export const defaultModelParameters: ModelParameters = {
@@ -102,7 +117,20 @@ function clampFinite(
     return Math.min(Math.max(finiteValue, min), max)
 }
 
-function minSegmentSize(total: number, maxSize: number): number {
-    const remainder = total % maxSize
-    return remainder > 0 ? Math.min(maxSize, remainder) : maxSize
+function extendMaxBoxSize(
+    total: number,
+    maxBoxSize: number,
+    minBoxSize: number
+): number {
+    const segments = segmentSizes(total, maxBoxSize)
+    if (segments.length === 1) return maxBoxSize
+
+    const lastSegmentSize = segments[segments.length - 1]
+    if (lastSegmentSize + dimensionTolerance >= minBoxSize) return maxBoxSize
+
+    return roundDimension(total / (segments.length - 1))
+}
+
+function roundDimension(value: number): number {
+    return Math.round(value * 1e10) / 1e10
 }

--- a/lib/parameterValidation.ts
+++ b/lib/parameterValidation.ts
@@ -1,5 +1,5 @@
 import { parameters } from '@/lib/defaults'
-import { dimensionTolerance, segmentSizes } from '@/lib/gridSizing'
+import { segmentSizes } from '@/lib/gridSizing'
 import type { StoreState } from '@/lib/types'
 
 export type ModelParameters = Pick<
@@ -123,18 +123,24 @@ function extendMaxBoxSize(
     minBoxSize: number
 ): number {
     const segments = segmentSizes(total, maxBoxSize, minBoxSize)
-    const hasUndersizedSegment = segments.some(
-        (size) => size + dimensionTolerance < minBoxSize
-    )
+    const hasUndersizedSegment = segments.some((size) => size < minBoxSize)
     if (!hasUndersizedSegment) return maxBoxSize
 
-    const maxValidSegmentCount = Math.max(
-        1,
-        Math.floor(total / minBoxSize + dimensionTolerance)
-    )
-    return roundDimension(total / maxValidSegmentCount)
+    let maxValidSegmentCount = Math.max(1, Math.floor(total / minBoxSize))
+    while (
+        maxValidSegmentCount > 1 &&
+        total / maxValidSegmentCount < minBoxSize
+    ) {
+        maxValidSegmentCount--
+    }
+
+    return roundDimensionUp(total / maxValidSegmentCount)
 }
 
 function roundDimension(value: number): number {
     return Math.round(value * 1e10) / 1e10
+}
+
+function roundDimensionUp(value: number): number {
+    return Math.ceil(value * 1e10) / 1e10
 }

--- a/lib/parameterValidation.ts
+++ b/lib/parameterValidation.ts
@@ -122,13 +122,17 @@ function extendMaxBoxSize(
     maxBoxSize: number,
     minBoxSize: number
 ): number {
-    const segments = segmentSizes(total, maxBoxSize)
-    if (segments.length === 1) return maxBoxSize
+    const segments = segmentSizes(total, maxBoxSize, minBoxSize)
+    const hasUndersizedSegment = segments.some(
+        (size) => size + dimensionTolerance < minBoxSize
+    )
+    if (!hasUndersizedSegment) return maxBoxSize
 
-    const lastSegmentSize = segments[segments.length - 1]
-    if (lastSegmentSize + dimensionTolerance >= minBoxSize) return maxBoxSize
-
-    return roundDimension(total / (segments.length - 1))
+    const maxValidSegmentCount = Math.max(
+        1,
+        Math.floor(total / minBoxSize + dimensionTolerance)
+    )
+    return roundDimension(total / maxValidSegmentCount)
 }
 
 function roundDimension(value: number): number {

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -73,6 +73,6 @@ function setModelParameter<K extends keyof ModelParameters>(
     value: number
 ): number {
     const next = sanitizeModelParameters({ ...get(), [key]: value }, get())
-    set({ [key]: next[key] } as Partial<StoreState>)
+    set(next)
     return next[key]
 }

--- a/tests/geometry.test.ts
+++ b/tests/geometry.test.ts
@@ -6,6 +6,7 @@ import {
     validateGridBoxCombination,
 } from '@/lib/gridCombine'
 import { gridMatchesLayout, resizeGrid } from '@/lib/gridHelper'
+import { dimensionTolerance } from '@/lib/gridSizing'
 import {
     getGridBoxes,
     isGridBoxVisible,
@@ -777,6 +778,46 @@ describe('grid resizing', () => {
 })
 
 describe('parameter validation', () => {
+    it('rounds a corrected maximum without creating another undersized segment', () => {
+        const sanitized = sanitizeModelParameters({
+            totalWidth: 41,
+            totalDepth: 1.2,
+            maxBoxWidth: 1.2,
+            maxBoxDepth: 1.2,
+            wallThickness: 0.1,
+            cornerRadius: 0,
+        })
+        const minBoxSize = getMinimumBoxSize(
+            sanitized.wallThickness,
+            sanitized.cornerRadius
+        )
+        const grid = resizeGrid(
+            [],
+            sanitized.totalWidth,
+            sanitized.totalDepth,
+            sanitized.maxBoxWidth,
+            sanitized.maxBoxDepth,
+            minBoxSize
+        )
+        const widths = grid[0].map((cell) => cell.width)
+
+        expect(minBoxSize).toBe(1.2)
+        expect(sanitized.maxBoxWidth).toBe(1.205882353)
+        expect(widths).toHaveLength(34)
+        expect(widths.every((width) => width >= minBoxSize)).toBe(true)
+        expect(
+            widths.every(
+                (width) => width - sanitized.maxBoxWidth <= dimensionTolerance
+            )
+        ).toBe(true)
+        expect(
+            Math.abs(
+                widths.reduce((sum, width) => sum + width, 0) -
+                    sanitized.totalWidth
+            )
+        ).toBeLessThanOrEqual(dimensionTolerance)
+    })
+
     it.each([
         [201, 100, 100, 3],
         [150, 149, 149, 2],
@@ -843,5 +884,145 @@ describe('parameter validation', () => {
         expect(Number.isFinite(sanitized.cornerRadius)).toBe(true)
         expect(sanitized.wallThickness).toBe(15)
         expect(sanitized.cornerRadius).toBe(30)
+    })
+
+    it('preserves sizing invariants across generated and boundary parameters', () => {
+        const wallThicknesses = [0.1, 0.2, 2, 7.3, 15]
+        const cornerRadii = [0, 0.1, 4, 12.7, 30]
+        let checkedConfigurations = 0
+
+        const expectSizingInvariants = (
+            wallThickness: number,
+            cornerRadius: number,
+            totalWidth: number,
+            maxBoxWidth: number
+        ) => {
+            const minBoxSize = getMinimumBoxSize(wallThickness, cornerRadius)
+            const sanitized = sanitizeModelParameters({
+                totalWidth,
+                totalDepth: minBoxSize,
+                maxBoxWidth,
+                maxBoxDepth: 500,
+                wallThickness,
+                cornerRadius,
+            })
+            const sanitizedAgain = sanitizeModelParameters(sanitized)
+            const grid = resizeGrid(
+                [],
+                sanitized.totalWidth,
+                sanitized.totalDepth,
+                sanitized.maxBoxWidth,
+                sanitized.maxBoxDepth,
+                minBoxSize
+            )
+            const resizedAgain = resizeGrid(
+                grid,
+                sanitized.totalWidth,
+                sanitized.totalDepth,
+                sanitized.maxBoxWidth,
+                sanitized.maxBoxDepth,
+                minBoxSize
+            )
+            const widths = grid[0].map((cell) => cell.width)
+            const depths = grid.map((row) => row[0].depth)
+
+            const sizes = [...widths, ...depths]
+            sizes.forEach((size) => {
+                expect(size).toBeGreaterThanOrEqual(minBoxSize)
+            })
+            widths.forEach((width) => {
+                expect(width - sanitized.maxBoxWidth).toBeLessThanOrEqual(
+                    dimensionTolerance
+                )
+            })
+            depths.forEach((depth) => {
+                expect(depth - sanitized.maxBoxDepth).toBeLessThanOrEqual(
+                    dimensionTolerance
+                )
+            })
+            expect(
+                Math.abs(
+                    widths.reduce((sum, width) => sum + width, 0) -
+                        sanitized.totalWidth
+                )
+            ).toBeLessThanOrEqual(dimensionTolerance)
+            expect(
+                Math.abs(
+                    depths.reduce((sum, depth) => sum + depth, 0) -
+                        sanitized.totalDepth
+                )
+            ).toBeLessThanOrEqual(dimensionTolerance)
+            expect(sanitizedAgain).toEqual(sanitized)
+            expect(resizedAgain).toEqual(grid)
+            checkedConfigurations++
+        }
+
+        wallThicknesses.forEach((wallThickness) => {
+            cornerRadii.forEach((cornerRadius) => {
+                const minBoxSize = getMinimumBoxSize(
+                    wallThickness,
+                    cornerRadius
+                )
+                const totals = [
+                    minBoxSize,
+                    minBoxSize + dimensionTolerance / 2,
+                    minBoxSize + dimensionTolerance * 10,
+                    41,
+                    100,
+                    201,
+                    500,
+                ].filter((total) => total >= minBoxSize && total <= 500)
+                const uniqueTotals = [...new Set(totals)]
+
+                uniqueTotals.forEach((totalWidth) => {
+                    const requestedMaxima = [
+                        1,
+                        minBoxSize,
+                        minBoxSize + dimensionTolerance / 2,
+                        Math.max(
+                            minBoxSize,
+                            totalWidth / 2 - dimensionTolerance / 2
+                        ),
+                        totalWidth / 2,
+                        totalWidth / 3,
+                        100,
+                        500,
+                    ]
+                    const uniqueMaxima = [...new Set(requestedMaxima)]
+
+                    uniqueMaxima.forEach((maxBoxWidth) => {
+                        expectSizingInvariants(
+                            wallThickness,
+                            cornerRadius,
+                            totalWidth,
+                            maxBoxWidth
+                        )
+                    })
+                })
+            })
+        })
+
+        let randomState = 0x224
+        const nextRandom = () => {
+            randomState = (Math.imul(randomState, 1664525) + 1013904223) >>> 0
+            return randomState / 0x1_0000_0000
+        }
+
+        for (let index = 0; index < 250; index++) {
+            const wallThickness = 0.1 + nextRandom() * 14.9
+            const cornerRadius = nextRandom() * 30
+            const minBoxSize = getMinimumBoxSize(wallThickness, cornerRadius)
+            const totalWidth = minBoxSize + nextRandom() * (500 - minBoxSize)
+            const maxBoxWidth = 1 + nextRandom() * 499
+
+            expectSizingInvariants(
+                wallThickness,
+                cornerRadius,
+                totalWidth,
+                maxBoxWidth
+            )
+        }
+
+        expect(checkedConfigurations).toBeGreaterThan(750)
     })
 })

--- a/tests/geometry.test.ts
+++ b/tests/geometry.test.ts
@@ -778,14 +778,14 @@ describe('grid resizing', () => {
 
 describe('parameter validation', () => {
     it.each([
-        [201, 100, 100.5],
-        [150, 149, 150],
-        [100, 1, 100 / 7],
-        [113, 100, 100],
-        [26.000000001, 13, 13],
+        [201, 100, 100, 3],
+        [150, 149, 149, 2],
+        [100, 1, 100 / 7, 7],
+        [113, 100, 100, 2],
+        [26.000000001, 13, 13, 2],
     ])(
         'keeps every segment valid for a %d mm total and %d mm requested max',
-        (total, requestedMax, expectedMax) => {
+        (total, requestedMax, expectedMax, expectedSegmentCount) => {
             const sanitized = sanitizeModelParameters({
                 totalWidth: total,
                 totalDepth: total,
@@ -803,12 +803,15 @@ describe('parameter validation', () => {
                 sanitized.totalWidth,
                 sanitized.totalDepth,
                 sanitized.maxBoxWidth,
-                sanitized.maxBoxDepth
+                sanitized.maxBoxDepth,
+                minBoxSize
             )
 
             expect(minBoxSize).toBe(13)
             expect(sanitized.maxBoxWidth).toBeCloseTo(expectedMax)
             expect(sanitized.maxBoxDepth).toBeCloseTo(expectedMax)
+            expect(grid).toHaveLength(expectedSegmentCount)
+            expect(grid[0]).toHaveLength(expectedSegmentCount)
             expect(
                 grid.every((row) =>
                     row.every(

--- a/tests/geometry.test.ts
+++ b/tests/geometry.test.ts
@@ -16,7 +16,10 @@ import {
     OutlineTopologyError,
     type OutlineTopologyCode,
 } from '@/lib/lineHelper'
-import { sanitizeModelParameters } from '@/lib/parameterValidation'
+import {
+    getMinimumBoxSize,
+    sanitizeModelParameters,
+} from '@/lib/parameterValidation'
 import { useStore } from '@/lib/store'
 import { Grid } from '@/lib/types'
 import * as THREE from 'three'
@@ -774,6 +777,49 @@ describe('grid resizing', () => {
 })
 
 describe('parameter validation', () => {
+    it.each([
+        [201, 100, 100.5],
+        [150, 149, 150],
+        [100, 1, 100 / 7],
+        [113, 100, 100],
+        [26.000000001, 13, 13],
+    ])(
+        'keeps every segment valid for a %d mm total and %d mm requested max',
+        (total, requestedMax, expectedMax) => {
+            const sanitized = sanitizeModelParameters({
+                totalWidth: total,
+                totalDepth: total,
+                maxBoxWidth: requestedMax,
+                maxBoxDepth: requestedMax,
+                wallThickness: 2,
+                cornerRadius: 4,
+            })
+            const minBoxSize = getMinimumBoxSize(
+                sanitized.wallThickness,
+                sanitized.cornerRadius
+            )
+            const grid = resizeGrid(
+                [],
+                sanitized.totalWidth,
+                sanitized.totalDepth,
+                sanitized.maxBoxWidth,
+                sanitized.maxBoxDepth
+            )
+
+            expect(minBoxSize).toBe(13)
+            expect(sanitized.maxBoxWidth).toBeCloseTo(expectedMax)
+            expect(sanitized.maxBoxDepth).toBeCloseTo(expectedMax)
+            expect(
+                grid.every((row) =>
+                    row.every(
+                        (cell) =>
+                            cell.width >= minBoxSize && cell.depth >= minBoxSize
+                    )
+                )
+            ).toBe(true)
+        }
+    )
+
     it('clamps invalid model parameters to finite safe values', () => {
         const sanitized = sanitizeModelParameters({
             totalWidth: Number.NaN,
@@ -786,13 +832,13 @@ describe('parameter validation', () => {
         })
 
         expect(sanitized.totalWidth).toBe(150)
-        expect(sanitized.totalDepth).toBe(1)
-        expect(sanitized.maxBoxWidth).toBe(1)
+        expect(sanitized.totalDepth).toBe(91)
+        expect(sanitized.maxBoxWidth).toBe(150)
         expect(sanitized.maxBoxDepth).toBe(100)
         expect(sanitized.wallHeight).toBe(30)
         expect(Number.isFinite(sanitized.wallThickness)).toBe(true)
         expect(Number.isFinite(sanitized.cornerRadius)).toBe(true)
-        expect(sanitized.wallThickness).toBeLessThanOrEqual(0.4)
-        expect(sanitized.cornerRadius).toBeLessThanOrEqual(0.5)
+        expect(sanitized.wallThickness).toBe(15)
+        expect(sanitized.cornerRadius).toBe(30)
     })
 })

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -1,4 +1,7 @@
-import { defaultModelParameters } from '@/lib/parameterValidation'
+import {
+    defaultModelParameters,
+    getMinimumBoxSize,
+} from '@/lib/parameterValidation'
 import { useStore } from '@/lib/store'
 import { beforeEach, describe, expect, it } from 'vitest'
 
@@ -8,35 +11,77 @@ describe('model parameter store', () => {
     })
 
     it.each([
-        ['total width', 'totalWidth', 'setTotalWidth', 201],
-        ['total depth', 'totalDepth', 'setTotalDepth', 201],
-        ['max box width', 'maxBoxWidth', 'setMaxBoxWidth', 149],
-        ['max box depth', 'maxBoxDepth', 'setMaxBoxDepth', 149],
+        ['total width', 'totalWidth', 'maxBoxWidth', 'setTotalWidth'],
+        ['total depth', 'totalDepth', 'maxBoxDepth', 'setTotalDepth'],
     ] as const)(
-        'preserves wall settings when changing %s across a segment boundary',
-        (_label, parameter, setter, value) => {
+        'extends the max box size when changing %s would create a tiny remainder',
+        (_label, parameter, maxBoxParameter, setter) => {
             const initial = useStore.getState()
 
-            initial[setter](value)
+            initial[setter](201)
 
             const updated = useStore.getState()
-            expect(updated[parameter]).toBe(value)
+            expect(updated[parameter]).toBe(201)
+            expect(updated[maxBoxParameter]).toBe(100.5)
             expect(updated.wallThickness).toBe(initial.wallThickness)
             expect(updated.cornerRadius).toBe(initial.cornerRadius)
         }
     )
 
+    it.each([
+        ['max box width', 'maxBoxWidth', 'setMaxBoxWidth'],
+        ['max box depth', 'maxBoxDepth', 'setMaxBoxDepth'],
+    ] as const)(
+        'extends %s when the requested value would create a tiny remainder',
+        (_label, parameter, setter) => {
+            const state = useStore.getState()
+
+            expect(state[setter](149)).toBe(150)
+            expect(useStore.getState()[parameter]).toBe(150)
+        }
+    )
+
+    it('gates total and max box dimensions at the smallest valid box size', () => {
+        const state = useStore.getState()
+        const minBoxSize = getMinimumBoxSize(
+            state.wallThickness,
+            state.cornerRadius
+        )
+
+        expect(minBoxSize).toBe(13)
+        expect(state.setTotalWidth(1)).toBe(minBoxSize)
+        expect(state.setMaxBoxWidth(1)).toBe(minBoxSize)
+        expect(useStore.getState()).toMatchObject({
+            totalWidth: minBoxSize,
+            maxBoxWidth: minBoxSize,
+        })
+    })
+
+    it('revalidates both grid axes when wall settings raise the minimum', () => {
+        const state = useStore.getState()
+
+        expect(state.setCornerRadius(30)).toBe(30)
+        expect(useStore.getState()).toMatchObject({
+            totalWidth: 150,
+            totalDepth: 150,
+            maxBoxWidth: 150,
+            maxBoxDepth: 150,
+            wallThickness: 2,
+            cornerRadius: 30,
+        })
+    })
+
     it('still clamps the parameter that is being changed', () => {
         const state = useStore.getState()
 
         expect(state.setWallThickness(999)).toBe(15)
-        expect(state.setCornerRadius(999)).toBe(25)
-        expect(state.setTotalWidth(-10)).toBe(1)
+        expect(state.setCornerRadius(999)).toBe(30)
+        expect(state.setTotalWidth(-10)).toBe(91)
 
         expect(useStore.getState()).toMatchObject({
             wallThickness: 15,
-            cornerRadius: 25,
-            totalWidth: 1,
+            cornerRadius: 30,
+            totalWidth: 91,
         })
     })
 })

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -14,7 +14,7 @@ describe('model parameter store', () => {
         ['total width', 'totalWidth', 'maxBoxWidth', 'setTotalWidth'],
         ['total depth', 'totalDepth', 'maxBoxDepth', 'setTotalDepth'],
     ] as const)(
-        'extends the max box size when changing %s would create a tiny remainder',
+        'preserves the max box size when changing %s can be balanced safely',
         (_label, parameter, maxBoxParameter, setter) => {
             const initial = useStore.getState()
 
@@ -22,7 +22,7 @@ describe('model parameter store', () => {
 
             const updated = useStore.getState()
             expect(updated[parameter]).toBe(201)
-            expect(updated[maxBoxParameter]).toBe(100.5)
+            expect(updated[maxBoxParameter]).toBe(100)
             expect(updated.wallThickness).toBe(initial.wallThickness)
             expect(updated.cornerRadius).toBe(initial.cornerRadius)
         }
@@ -32,14 +32,23 @@ describe('model parameter store', () => {
         ['max box width', 'maxBoxWidth', 'setMaxBoxWidth'],
         ['max box depth', 'maxBoxDepth', 'setMaxBoxDepth'],
     ] as const)(
-        'extends %s when the requested value would create a tiny remainder',
+        'preserves %s when the requested layout can be balanced safely',
         (_label, parameter, setter) => {
             const state = useStore.getState()
 
-            expect(state[setter](149)).toBe(150)
-            expect(useStore.getState()[parameter]).toBe(150)
+            expect(state[setter](149)).toBe(149)
+            expect(useStore.getState()[parameter]).toBe(149)
         }
     )
+
+    it('extends max box width only when balancing cannot satisfy the minimum', () => {
+        const state = useStore.getState()
+
+        state.setTotalWidth(100)
+
+        expect(state.setMaxBoxWidth(13)).toBeCloseTo(100 / 7)
+        expect(useStore.getState().maxBoxWidth).toBeCloseTo(100 / 7)
+    })
 
     it('gates total and max box dimensions at the smallest valid box size', () => {
         const state = useStore.getState()
@@ -64,8 +73,8 @@ describe('model parameter store', () => {
         expect(useStore.getState()).toMatchObject({
             totalWidth: 150,
             totalDepth: 150,
-            maxBoxWidth: 150,
-            maxBoxDepth: 150,
+            maxBoxWidth: 100,
+            maxBoxDepth: 100,
             wallThickness: 2,
             cornerRadius: 30,
         })


### PR DESCRIPTION
## Summary

- enforce a minimum box dimension of twice the wall thickness plus twice the corner radius and 1 mm clearance
- raise total and max-box slider minimums dynamically from the active wall settings
- rebalance grid segments when a greedy final segment would be too small
- preserve the configured max-box dimension whenever a valid balanced partition exists
- increase the max-box dimension only when no partition under the requested maximum can satisfy the minimum
- round corrected maxima upward so precision loss cannot add an extra undersized segment
- use a dimensionally consistent millimetre tolerance for segment-count boundaries
- share segment sizing between validation and grid construction
- add exact regression, boundary, and deterministic generated invariant coverage

## Why

A total width, total depth, or max-box-size change could leave a final grid segment smaller than the walls and rounded corners require. That produced boxes with no usable inner area and malformed corner geometry.

A small remainder does not necessarily require changing the user's maximum box size. The grid can usually be redistributed into more, evenly sized boxes that stay below the configured maximum. The maximum is now adjusted only when even that balanced partition would contain undersized boxes.

Corrected maximum values also need directional rounding. Rounding `total / segmentCount` to the nearest decimal representation could round downward, causing layout to derive one additional segment and violate the minimum again. Corrected maxima now round upward, while count tolerance is applied in millimetres rather than quotient space.

## Impact

Resizing no longer creates zero-inner-size boxes or unnecessarily changes the configured maximum. For example, a 201 mm total with a 100 mm maximum becomes three 67 mm boxes while the maximum remains 100 mm.

The reported `total=41`, `wallThickness=0.1`, `cornerRadius=0`, `max=1.2` case now produces 34 boxes, each at least 1.2 mm, with a sanitized maximum of 1.205882353 mm.

## Validation

- `npm test` — 67 tests passed
- exact regression for the reported 41 / 1.2 failure
- generated and boundary sweep over more than 750 configurations, including 250 deterministic generated cases
- invariant checks: minimum size, maximum plus millimetre tolerance, exact total, repeated sanitization stability, and repeated resizing stability
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
