### PR TITLE
Validate printable STL and 3MF exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Bottomed boxes are generated as one stitched solid rather than overlapping wall
 and bottom meshes. Bottomless boxes are closed wall shells. Display helpers,
 selection state, colors, and camera state are not part of any export.
 
+Exports support up to 2,500 grid cells, 250 visible parts, and a 32 MB finished
+artifact. Geometry and compression run in a cancellable worker so the editor
+remains responsive; the supported limit is stress-tested against a 128 MB worker
+heap-growth budget. Excess models are rejected with an actionable message before
+mesh generation, and hidden boxes are filtered before geometry is materialized.
+
 ## Getting Started
 
 First, run the development server:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,22 @@ Simple parameterized generator to create a grid of boxes for 3D printing. The gr
 
 Play with it here: [box-grid.timoweiss.me](https://box-grid.timoweiss.me)
 
+## Printable exports
+
+- **STL print plate** exports every visible box as a binary STL and places 5 mm
+  between parts. Each part is a closed manifold shell, so adjacent drawer boxes
+  do not introduce coincident faces in the file.
+- **3MF** exports the same deterministic print-plate layout in millimeters while
+  preserving each box as a separate object.
+- **Separate STL ZIP** exports one binary STL per unique design. Identical
+  designs are counted by generated mesh shape (including rotated equivalents),
+  while different non-rectangular shapes with the same bounding dimensions stay
+  separate.
+
+Bottomed boxes are generated as one stitched solid rather than overlapping wall
+and bottom meshes. Bottomless boxes are closed wall shells. Display helpers,
+selection state, colors, and camera state are not part of any export.
+
 ## Getting Started
 
 First, run the development server:

--- a/components/ExportButton.tsx
+++ b/components/ExportButton.tsx
@@ -1,4 +1,5 @@
 'use client'
+
 import { Button } from '@/components/ui/button'
 import {
     DropdownMenu,
@@ -6,28 +7,109 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import {
-    handleExportMultipleSTLs,
-    handleStlExport,
-    handleThreeMfExport,
-} from '@/lib/exportUtils'
+import type { ExportFormat, ExportProgress } from '@/lib/exportProtocol'
+import type { PrintableModel } from '@/lib/printableModel'
+import { useStore } from '@/lib/store'
+import { useRef, useState } from 'react'
+import { toast } from 'sonner'
 
 export default function ExportButton() {
+    const [isExporting, setIsExporting] = useState(false)
+    const cancellation = useRef<AbortController | null>(null)
+    const hasVisibleParts = useStore((state) =>
+        state.grid.some((row) =>
+            row.some((cell) => cell.visibility !== 'hidden')
+        )
+    )
+
+    const startExport = async (format: ExportFormat) => {
+        if (cancellation.current) return
+        const controller = new AbortController()
+        cancellation.current = controller
+        setIsExporting(true)
+        const cancel = () => controller.abort()
+        const toastId = toast.loading('Preparing export…', {
+            description: '0%',
+            action: { label: 'Cancel', onClick: cancel },
+        })
+
+        try {
+            const state = useStore.getState()
+            const model: PrintableModel = {
+                totalWidth: state.totalWidth,
+                totalDepth: state.totalDepth,
+                wallThickness: state.wallThickness,
+                cornerRadius: state.cornerRadius,
+                wallHeight: state.wallHeight,
+                generateBottom: state.generateBottom,
+                grid: state.grid.map((row) => row.map((cell) => ({ ...cell }))),
+            }
+            const { downloadExport, runExport } =
+                await import('@/lib/exportClient')
+            const updateProgress = ({ percent, message }: ExportProgress) =>
+                toast.loading(message, {
+                    id: toastId,
+                    description: `${percent}%`,
+                    action: { label: 'Cancel', onClick: cancel },
+                })
+            const exported = await runExport({
+                format,
+                model,
+                signal: controller.signal,
+                onProgress: updateProgress,
+            })
+            downloadExport(exported)
+            toast.success('Export ready', {
+                id: toastId,
+                description: exported.filename,
+            })
+        } catch (error) {
+            if (error instanceof DOMException && error.name === 'AbortError') {
+                toast.info('Export cancelled', { id: toastId })
+            } else {
+                toast.error('Export failed', {
+                    id: toastId,
+                    description:
+                        error instanceof Error
+                            ? error.message
+                            : 'The export could not be generated.',
+                })
+            }
+        } finally {
+            cancellation.current = null
+            setIsExporting(false)
+        }
+    }
+
+    const disabled = isExporting || !hasVisibleParts
     return (
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
-                <Button size="sm" className="w-full">
-                    Export Model
+                <Button
+                    size="sm"
+                    className="w-full"
+                    disabled={disabled}
+                    title={
+                        !hasVisibleParts
+                            ? 'There are no visible boxes to export.'
+                            : undefined
+                    }
+                >
+                    {!hasVisibleParts
+                        ? 'No visible boxes'
+                        : isExporting
+                          ? 'Exporting…'
+                          : 'Export Model'}
                 </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent>
-                <DropdownMenuItem onClick={handleStlExport}>
+                <DropdownMenuItem onClick={() => startExport('stl')}>
                     Export as STL (Print Plate)
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={handleThreeMfExport}>
+                <DropdownMenuItem onClick={() => startExport('3mf')}>
                     Export as 3MF
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={handleExportMultipleSTLs}>
+                <DropdownMenuItem onClick={() => startExport('zip')}>
                     Export as ZIP (Separate STL Files)
                 </DropdownMenuItem>
             </DropdownMenuContent>

--- a/components/ExportButton.tsx
+++ b/components/ExportButton.tsx
@@ -6,7 +6,11 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { handleExportMultipleSTLs, handleStlExport } from '@/lib/exportUtils'
+import {
+    handleExportMultipleSTLs,
+    handleStlExport,
+    handleThreeMfExport,
+} from '@/lib/exportUtils'
 
 export default function ExportButton() {
     return (
@@ -18,7 +22,10 @@ export default function ExportButton() {
             </DropdownMenuTrigger>
             <DropdownMenuContent>
                 <DropdownMenuItem onClick={handleStlExport}>
-                    Export as STL (Single Object)
+                    Export as STL (Print Plate)
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={handleThreeMfExport}>
+                    Export as 3MF
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={handleExportMultipleSTLs}>
                     Export as ZIP (Separate STL Files)

--- a/lib/boxHelper.ts
+++ b/lib/boxHelper.ts
@@ -1,7 +1,7 @@
 import {
     createCornerLines,
     getOutline,
-    getRoundedOutline,
+    getRoundedOutlineGeometry,
     offsetPolygonCCW,
 } from '@/lib/lineHelper'
 import { Cell, Grid } from '@/lib/types'
@@ -30,6 +30,9 @@ export function generateCustomBox(
     }
 
     const group = new THREE.Group()
+    const bottomThickness = options.generateBottom
+        ? Math.min(options.wallThickness, options.wallHeight)
+        : 0
     const ids = Array.from(new Set(grid.flat().map((c) => c.group))).filter(
         (i) => i > 0
     )
@@ -61,14 +64,14 @@ export function generateCustomBox(
         if (!rawO.length) return
 
         const rawI = offsetPolygonCCW(rawO, options.wallThickness)
-        const outR = getRoundedOutline(
+        const outerOutline = getRoundedOutlineGeometry(
             rawO,
             options.cornerRadius,
             5,
             options.cornerRadius,
             options.wallThickness
         )
-        const inR = getRoundedOutline(
+        const innerOutline = getRoundedOutlineGeometry(
             rawI,
             options.cornerRadius - options.wallThickness,
             5,
@@ -92,18 +95,16 @@ export function generateCustomBox(
 
         boxGroup.add(
             buildBoxMesh(
-                outR,
-                inR,
+                outerOutline,
+                innerOutline,
                 options.wallHeight,
-                options.generateBottom
-                    ? Math.min(options.wallThickness, options.wallHeight)
-                    : undefined
+                options.generateBottom ? bottomThickness : undefined
             )
         )
 
         if (options.cornerLines.show) {
             const cornerLines = createCornerLines(
-                outR,
+                outerOutline.points,
                 options.wallHeight,
                 options.cornerLines.color,
                 options.cornerLines.opacity,
@@ -135,14 +136,14 @@ export function generateCustomBox(
             ]
             const rawO = getOutline(singleGrid, 0)
             const rawI = offsetPolygonCCW(rawO, options.wallThickness)
-            const outR = getRoundedOutline(
+            const outerOutline = getRoundedOutlineGeometry(
                 rawO,
                 options.cornerRadius,
                 5,
                 options.cornerRadius,
                 options.wallThickness
             )
-            const inR = getRoundedOutline(
+            const innerOutline = getRoundedOutlineGeometry(
                 rawI,
                 options.cornerRadius - options.wallThickness,
                 5,
@@ -151,11 +152,11 @@ export function generateCustomBox(
             )
             const x0 = cumW[x],
                 z0 = cumD[z]
-            outR.forEach((p) => {
+            outerOutline.points.forEach((p) => {
                 p.x += x0
                 p.y += z0
             })
-            inR.forEach((p) => {
+            innerOutline.points.forEach((p) => {
                 p.x += x0
                 p.y += z0
             })
@@ -165,18 +166,16 @@ export function generateCustomBox(
             cellGroup.visible = cell.visibility !== 'hidden'
             cellGroup.add(
                 buildBoxMesh(
-                    outR,
-                    inR,
+                    outerOutline,
+                    innerOutline,
                     options.wallHeight,
-                    options.generateBottom
-                        ? Math.min(options.wallThickness, options.wallHeight)
-                        : undefined
+                    options.generateBottom ? bottomThickness : undefined
                 )
             )
 
             if (options.cornerLines.show) {
                 const outerLines = createCornerLines(
-                    outR,
+                    outerOutline.points,
                     options.wallHeight,
                     options.cornerLines.color,
                     options.cornerLines.opacity,
@@ -185,11 +184,11 @@ export function generateCustomBox(
                 cellGroup.add(outerLines)
 
                 const innerLines = createCornerLines(
-                    inR,
+                    innerOutline.points,
                     options.wallHeight,
                     options.cornerLines.color,
                     options.cornerLines.opacity,
-                    options.generateBottom ? options.wallThickness : 0,
+                    bottomThickness,
                     true
                 )
                 cellGroup.add(innerLines)

--- a/lib/boxHelper.ts
+++ b/lib/boxHelper.ts
@@ -6,7 +6,7 @@ import {
 } from '@/lib/lineHelper'
 import { Cell, Grid } from '@/lib/types'
 import * as THREE from 'three'
-import { buildBottomMesh, buildWallMesh } from './meshHelper'
+import { buildBoxMesh } from './meshHelper'
 
 export type BoxGenerationOptions = {
     wallThickness: number
@@ -88,9 +88,14 @@ export function generateCustomBox(
         boxGroup.name = `group:${id}`
         boxGroup.visible = isBoxVisible
 
-        boxGroup.add(buildWallMesh(outR, inR, options.wallHeight))
-        if (options.generateBottom)
-            boxGroup.add(buildBottomMesh(outR, options.wallThickness))
+        boxGroup.add(
+            buildBoxMesh(
+                outR,
+                inR,
+                options.wallHeight,
+                options.generateBottom ? options.wallThickness : undefined
+            )
+        )
 
         if (options.cornerLines.show) {
             const cornerLines = createCornerLines(
@@ -152,9 +157,14 @@ export function generateCustomBox(
             const cellGroup = new THREE.Group()
             cellGroup.name = `cell:${x}:${z}`
             cellGroup.visible = cell.visibility !== 'hidden'
-            cellGroup.add(buildWallMesh(outR, inR, options.wallHeight))
-            if (options.generateBottom)
-                cellGroup.add(buildBottomMesh(outR, options.wallThickness))
+            cellGroup.add(
+                buildBoxMesh(
+                    outR,
+                    inR,
+                    options.wallHeight,
+                    options.generateBottom ? options.wallThickness : undefined
+                )
+            )
 
             if (options.cornerLines.show) {
                 const outerLines = createCornerLines(

--- a/lib/boxHelper.ts
+++ b/lib/boxHelper.ts
@@ -13,6 +13,7 @@ export type BoxGenerationOptions = {
     cornerRadius: number
     wallHeight: number
     generateBottom: boolean
+    includeHidden?: boolean
     cornerLines: {
         show: boolean
         color: number
@@ -55,6 +56,7 @@ export function generateCustomBox(
             }
         }
 
+        if (!isBoxVisible && options.includeHidden === false) return
         const rawO = getOutline(grid, id)
         if (!rawO.length) return
 
@@ -93,7 +95,9 @@ export function generateCustomBox(
                 outR,
                 inR,
                 options.wallHeight,
-                options.generateBottom ? options.wallThickness : undefined
+                options.generateBottom
+                    ? Math.min(options.wallThickness, options.wallHeight)
+                    : undefined
             )
         )
 
@@ -116,6 +120,8 @@ export function generateCustomBox(
         for (let x = 0; x < grid[0].length; x++) {
             const cell = grid[z][x]
             if (cell.group !== 0) continue
+            if (cell.visibility === 'hidden' && options.includeHidden === false)
+                continue
 
             const singleGrid: Cell[][] = [
                 [
@@ -162,7 +168,9 @@ export function generateCustomBox(
                     outR,
                     inR,
                     options.wallHeight,
-                    options.generateBottom ? options.wallThickness : undefined
+                    options.generateBottom
+                        ? Math.min(options.wallThickness, options.wallHeight)
+                        : undefined
                 )
             )
 

--- a/lib/exportClient.ts
+++ b/lib/exportClient.ts
@@ -1,0 +1,97 @@
+import type {
+    ExportFormat,
+    ExportProgress,
+    ExportWorkerRequest,
+    ExportWorkerResponse,
+} from '@/lib/exportProtocol'
+import type { PrintableModel } from '@/lib/printableModel'
+
+export type CompletedExport = {
+    data: ArrayBuffer
+    filename: string
+    contentType: string
+}
+
+export async function runExport({
+    format,
+    model,
+    signal,
+    onProgress,
+}: {
+    format: ExportFormat
+    model: PrintableModel
+    signal: AbortSignal
+    onProgress: (progress: ExportProgress) => void
+}): Promise<CompletedExport> {
+    if (signal.aborted) {
+        throw new DOMException('Export cancelled.', 'AbortError')
+    }
+    const worker = new Worker(new URL('./exportWorker.ts', import.meta.url), {
+        type: 'module',
+    })
+
+    try {
+        const data = await new Promise<ArrayBuffer>((resolve, reject) => {
+            const abort = () => {
+                worker.terminate()
+                reject(new DOMException('Export cancelled.', 'AbortError'))
+            }
+            signal.addEventListener('abort', abort, { once: true })
+            worker.onmessage = ({
+                data,
+            }: MessageEvent<ExportWorkerResponse>) => {
+                if (data.type === 'progress') {
+                    onProgress(data)
+                    return
+                }
+                signal.removeEventListener('abort', abort)
+                if (data.type === 'result') resolve(data.data)
+                else {
+                    const error = new Error(data.message)
+                    error.name = data.name
+                    reject(error)
+                }
+            }
+            worker.onerror = (event) => {
+                signal.removeEventListener('abort', abort)
+                reject(new Error(event.message || 'The export worker failed.'))
+            }
+            const request: ExportWorkerRequest = { format, model }
+            worker.postMessage(request)
+        })
+
+        const formatDimension = (value: number) =>
+            Number(value.toFixed(4)).toString()
+        const base = `drawer-inserts-${formatDimension(model.totalWidth)}x${formatDimension(model.totalDepth)}x${formatDimension(model.wallHeight)}`
+        if (format === 'stl') {
+            return {
+                data,
+                filename: `${base}-print-plate.stl`,
+                contentType: 'model/stl',
+            }
+        }
+        if (format === '3mf') {
+            return { data, filename: `${base}.3mf`, contentType: 'model/3mf' }
+        }
+        return {
+            data,
+            filename: `${base}-grid.zip`,
+            contentType: 'application/zip',
+        }
+    } finally {
+        worker.terminate()
+    }
+}
+
+export function downloadExport(exported: CompletedExport): void {
+    const href = URL.createObjectURL(
+        new Blob([exported.data], { type: exported.contentType })
+    )
+    const link = document.createElement('a')
+    link.href = href
+    link.download = exported.filename
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    setTimeout(() => URL.revokeObjectURL(href), 100)
+}

--- a/lib/exportProtocol.ts
+++ b/lib/exportProtocol.ts
@@ -1,0 +1,18 @@
+import type { PrintableModel } from '@/lib/printableModel'
+
+export type ExportFormat = 'stl' | '3mf' | 'zip'
+
+export type ExportWorkerRequest = {
+    format: ExportFormat
+    model: PrintableModel
+}
+
+export type ExportProgress = {
+    percent: number
+    message: string
+}
+
+export type ExportWorkerResponse =
+    | ({ type: 'progress' } & ExportProgress)
+    | { type: 'result'; data: ArrayBuffer }
+    | { type: 'error'; name: string; message: string; code?: string }

--- a/lib/exportUtils.ts
+++ b/lib/exportUtils.ts
@@ -1,11 +1,11 @@
 import {
     buildPrintableParts,
+    exportLimits,
+    ExportModelError,
     groupPrintableParts,
-    snapshotPrintableModel,
     type PrintableModel,
     type PrintablePart,
 } from '@/lib/printableModel'
-import { useStore } from '@/lib/store'
 import { disposeObject } from '@/lib/threeDisposal'
 import { exportThreeMf } from '@/lib/threeMfExporter'
 import JSZip from 'jszip'
@@ -18,7 +18,9 @@ export function generateStl(model: PrintableModel): ArrayBuffer {
     const parts = buildPrintableParts(model)
     if (parts.length === 0) throw new Error('Cannot export an empty STL model.')
     layoutPartsOnPrintPlate(parts, printPlateWidth(model))
-    return exportPartsAsStl(parts)
+    const output = exportPartsAsStl(parts)
+    validateOutputSize(output.byteLength)
+    return output
 }
 
 export async function generateThreeMf(
@@ -29,7 +31,9 @@ export async function generateThreeMf(
     layoutPartsOnPrintPlate(parts, printPlateWidth(model))
     const printable = orientForPrinting(parts.map((part) => part.object))
     try {
-        return await exportThreeMf(printable, exportBaseName(model))
+        const output = await exportThreeMf(printable, exportBaseName(model))
+        validateOutputSize(output.byteLength)
+        return output
     } finally {
         disposeObject(printable)
     }
@@ -52,7 +56,7 @@ export async function generateSeparateStlZip(
             (a, b) => a - b
         )
         const quantity = count > 1 ? `_qty${count}` : ''
-        const filename = `${isCombined ? 'combined_box' : 'box'}_${uniqueIndex}_${width.toFixed(0)}x${depth.toFixed(0)}x${dimensions.height.toFixed(0)}mm${quantity}.stl`
+        const filename = `${isCombined ? 'combined_box' : 'box'}_${uniqueIndex}_${formatDimension(width)}x${formatDimension(depth)}x${formatDimension(dimensions.height)}mm${quantity}.stl`
         zip.file(filename, exportPartsAsStl([representative]))
         uniqueIndex++
     }
@@ -61,41 +65,13 @@ export async function generateSeparateStlZip(
     parts.forEach((part) => {
         if (part.object.parent === null) disposeObject(part.object)
     })
-    return zip.generateAsync({
+    const output = await zip.generateAsync({
         type: 'uint8array',
         compression: 'DEFLATE',
         compressionOptions: { level: 6 },
     })
-}
-
-export function handleStlExport(): void {
-    const model = snapshotPrintableModel(useStore.getState())
-    if (model.grid.length === 0) return
-    download(
-        generateStl(model),
-        `${exportBaseName(model)}-print-plate.stl`,
-        'model/stl'
-    )
-}
-
-export async function handleThreeMfExport(): Promise<void> {
-    const model = snapshotPrintableModel(useStore.getState())
-    if (model.grid.length === 0) return
-    download(
-        await generateThreeMf(model),
-        `${exportBaseName(model)}.3mf`,
-        'model/3mf'
-    )
-}
-
-export async function handleExportMultipleSTLs(): Promise<void> {
-    const model = snapshotPrintableModel(useStore.getState())
-    if (model.grid.length === 0) return
-    download(
-        await generateSeparateStlZip(model),
-        `${exportBaseName(model)}-grid.zip`,
-        'application/zip'
-    )
+    validateOutputSize(output.byteLength)
+    return output
 }
 
 function exportPartsAsStl(parts: PrintablePart[]): ArrayBuffer {
@@ -159,7 +135,19 @@ function orientForPrinting(objects: THREE.Object3D[]): THREE.Group {
 }
 
 function exportBaseName(model: PrintableModel): string {
-    return `drawer-inserts-${model.totalWidth}x${model.totalDepth}x${model.wallHeight}`
+    return `drawer-inserts-${formatDimension(model.totalWidth)}x${formatDimension(model.totalDepth)}x${formatDimension(model.wallHeight)}`
+}
+
+function formatDimension(value: number): string {
+    return Number(value.toFixed(4)).toString()
+}
+
+function validateOutputSize(byteLength: number): void {
+    if (byteLength <= exportLimits.maxOutputBytes) return
+    throw new ExportModelError(
+        'output-limit',
+        `The generated file is larger than the supported ${exportLimits.maxOutputBytes / 1024 / 1024} MB export limit.`
+    )
 }
 
 function printPlateWidth(model: PrintableModel): number {
@@ -188,23 +176,4 @@ Designs are deduplicated by their generated mesh shape, including non-rectangula
 Thanks for using Box Grid Generator by timoweiss.me!
 Happy printing!
 `
-}
-
-function download(
-    data: ArrayBuffer | Uint8Array,
-    filename: string,
-    contentType: string
-): void {
-    const blobData =
-        data instanceof Uint8Array ? new Uint8Array(data).buffer : data
-    const href = URL.createObjectURL(
-        new Blob([blobData], { type: contentType })
-    )
-    const link = document.createElement('a')
-    link.href = href
-    link.download = filename
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
-    setTimeout(() => URL.revokeObjectURL(href), 100)
 }

--- a/lib/exportUtils.ts
+++ b/lib/exportUtils.ts
@@ -1,188 +1,210 @@
-import { generateCustomBox } from '@/lib/boxHelper'
-import { getGridBoxes } from '@/lib/gridVisibility'
+import {
+    buildPrintableParts,
+    groupPrintableParts,
+    snapshotPrintableModel,
+    type PrintableModel,
+    type PrintablePart,
+} from '@/lib/printableModel'
 import { useStore } from '@/lib/store'
 import { disposeObject } from '@/lib/threeDisposal'
+import { exportThreeMf } from '@/lib/threeMfExporter'
+import JSZip from 'jszip'
 import * as THREE from 'three'
 import { STLExporter } from 'three/examples/jsm/exporters/STLExporter.js'
 
-/**
- * Export the entire scene as one single STL
- */
-export function handleStlExport(): void {
-    const state = useStore.getState()
-    const grid = state.grid
-    if (grid.length === 0) return
+const printPlateGap = 5
 
-    // Wrap & rotate so Three's Y-up becomes STL Z-up
-    const tmpScene = new THREE.Scene()
-    const box = generateCustomBox(grid, {
-        wallThickness: state.wallThickness,
-        cornerRadius: state.cornerRadius,
-        wallHeight: state.wallHeight,
-        generateBottom: state.generateBottom,
-        cornerLines: {
-            show: false,
-            color: state.cornerLineColor,
-            opacity: state.cornerLineOpacity,
-        },
-    })
-    removeHiddenObjects(box)
-    box.position.set(0, 0, 0)
-    box.rotation.set(Math.PI / 2, 0, 0)
-    tmpScene.add(box)
-    tmpScene.updateMatrixWorld()
-
-    const exporter = new STLExporter()
-    let stlString: string
-    try {
-        stlString = exporter.parse(tmpScene, { binary: false })
-    } catch {
-        stlString = exporter.parse(tmpScene)
-    }
-
-    const blob = new Blob([stlString], { type: 'text/plain' })
-    const link = document.createElement('a')
-    link.href = URL.createObjectURL(blob)
-    link.download = `drawer-inserts-${state.totalWidth}x${state.totalDepth}x${state.wallHeight}-single-box.stl`
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
-    setTimeout(() => URL.revokeObjectURL(link.href), 100)
+export function generateStl(model: PrintableModel): ArrayBuffer {
+    const parts = buildPrintableParts(model)
+    if (parts.length === 0) throw new Error('Cannot export an empty STL model.')
+    layoutPartsOnPrintPlate(parts, printPlateWidth(model))
+    return exportPartsAsStl(parts)
 }
 
-/**
- * Export unique boxes (deduped by W×D×H, swap-insensitive) as separate STLs
- * with a `_qtyN` suffix and pack into a ZIP.
- */
-export async function handleExportMultipleSTLs(): Promise<void> {
-    const state = useStore.getState()
-    const grid = state.grid
-    if (grid.length === 0) return
-
-    const boxGroup = generateCustomBox(grid, {
-        wallThickness: state.wallThickness,
-        cornerRadius: state.cornerRadius,
-        wallHeight: state.wallHeight,
-        generateBottom: state.generateBottom,
-        cornerLines: {
-            show: false,
-            color: state.cornerLineColor,
-            opacity: state.cornerLineOpacity,
-        },
-    })
-
-    const boxWidths = grid[0].map((cell) => cell.width)
-    const boxDepths = grid.map((row) => row[0].depth)
-    const gridBoxes = getGridBoxes(grid, state.wallHeight)
-
-    // group boxes by dimensions (ignoring width↔depth swap)
-    type GroupInfo = {
-        representative: THREE.Object3D
-        count: number
-        w: number
-        d: number
-        h: number
-        isCombined: boolean
+export async function generateThreeMf(
+    model: PrintableModel
+): Promise<Uint8Array> {
+    const parts = buildPrintableParts(model)
+    if (parts.length === 0) throw new Error('Cannot export an empty 3MF model.')
+    layoutPartsOnPrintPlate(parts, printPlateWidth(model))
+    const printable = orientForPrinting(parts.map((part) => part.object))
+    try {
+        return await exportThreeMf(printable, exportBaseName(model))
+    } finally {
+        disposeObject(printable)
     }
-    const groups = new Map<string, GroupInfo>()
+}
 
-    boxGroup.children.forEach((box) => {
-        const metadata = gridBoxes.find((entry) => entry.id === box.name)
-        if (!metadata || metadata.visibility === 'hidden') return
+export async function generateSeparateStlZip(
+    model: PrintableModel
+): Promise<Uint8Array> {
+    const parts = buildPrintableParts(model)
+    const groups = groupPrintableParts(parts)
+    if (groups.length === 0)
+        throw new Error('Cannot export an empty STL archive.')
 
-        const rawW = metadata.dimensions.width
-        const rawD = metadata.dimensions.depth
-        const h = metadata.dimensions.height
-        const isCombined = metadata.isCombined
-        const [w, d] = [rawW, rawD].sort((a, b) => a - b)
-        const prefix = isCombined ? 'combined_box' : 'box'
-        const key = `${prefix}_${w.toFixed(2)}_${d.toFixed(2)}_${h.toFixed(2)}`
-
-        if (groups.has(key)) {
-            groups.get(key)!.count++
-        } else {
-            groups.set(key, {
-                representative: box,
-                count: 1,
-                w,
-                d,
-                h,
-                isCombined,
-            })
-        }
-    })
-
-    const JSZip = (await import('jszip')).default
     const zip = new JSZip()
-    const exporter = new STLExporter()
-    let uniqIndex = 1
-
-    for (const [, info] of groups) {
-        const { representative, count, w, d, h, isCombined } = info
-
-        // Wrap & rotate so Three's Y-up becomes STL Z-up
-        const tmpScene = new THREE.Scene()
-        const sceneClone = representative.clone(true)
-        sceneClone.position.set(0, 0, 0)
-        sceneClone.rotation.set(Math.PI / 2, 0, 0)
-        tmpScene.add(sceneClone)
-        tmpScene.updateMatrixWorld()
-
-        let stlString: string
-        try {
-            stlString = exporter.parse(tmpScene, { binary: false })
-        } catch {
-            stlString = exporter.parse(tmpScene)
-        }
-
-        const qtySuffix = count > 1 ? `_qty${count}` : ''
-        const filename = `${isCombined ? 'combined_box' : 'box'}_${uniqIndex}_${w.toFixed(0)}x${d.toFixed(0)}x${h.toFixed(0)}mm${qtySuffix}.stl`
-        zip.file(filename, stlString)
-        uniqIndex++
+    let uniqueIndex = 1
+    for (const group of groups) {
+        const { representative, count } = group
+        const { dimensions, isCombined } = representative.metadata
+        const [width, depth] = [dimensions.width, dimensions.depth].sort(
+            (a, b) => a - b
+        )
+        const quantity = count > 1 ? `_qty${count}` : ''
+        const filename = `${isCombined ? 'combined_box' : 'box'}_${uniqueIndex}_${width.toFixed(0)}x${depth.toFixed(0)}x${dimensions.height.toFixed(0)}mm${quantity}.stl`
+        zip.file(filename, exportPartsAsStl([representative]))
+        uniqueIndex++
     }
 
-    // README
-    const uniqueCount = groups.size
-    const cols = boxWidths.length
-    const rows = boxDepths.length
-    const readme = `# Box Grid Export
+    zip.file('README.txt', archiveReadme(model, groups.length))
+    parts.forEach((part) => {
+        if (part.object.parent === null) disposeObject(part.object)
+    })
+    return zip.generateAsync({
+        type: 'uint8array',
+        compression: 'DEFLATE',
+        compressionOptions: { level: 6 },
+    })
+}
+
+export function handleStlExport(): void {
+    const model = snapshotPrintableModel(useStore.getState())
+    if (model.grid.length === 0) return
+    download(
+        generateStl(model),
+        `${exportBaseName(model)}-print-plate.stl`,
+        'model/stl'
+    )
+}
+
+export async function handleThreeMfExport(): Promise<void> {
+    const model = snapshotPrintableModel(useStore.getState())
+    if (model.grid.length === 0) return
+    download(
+        await generateThreeMf(model),
+        `${exportBaseName(model)}.3mf`,
+        'model/3mf'
+    )
+}
+
+export async function handleExportMultipleSTLs(): Promise<void> {
+    const model = snapshotPrintableModel(useStore.getState())
+    if (model.grid.length === 0) return
+    download(
+        await generateSeparateStlZip(model),
+        `${exportBaseName(model)}-grid.zip`,
+        'application/zip'
+    )
+}
+
+function exportPartsAsStl(parts: PrintablePart[]): ArrayBuffer {
+    const objects = parts.map((part) => part.object)
+    const printable = orientForPrinting(objects)
+    try {
+        const output: unknown = new STLExporter().parse(printable, {
+            binary: true,
+        })
+        if (output instanceof ArrayBuffer) return output
+        if (ArrayBuffer.isView(output)) {
+            return new Uint8Array(
+                output.buffer,
+                output.byteOffset,
+                output.byteLength
+            ).slice().buffer
+        }
+        throw new Error('STL exporter did not return binary output.')
+    } finally {
+        disposeObject(printable)
+    }
+}
+
+function layoutPartsOnPrintPlate(
+    parts: PrintablePart[],
+    maximumRowWidth: number
+): void {
+    let x = 0
+    let z = 0
+    let rowDepth = 0
+
+    parts.forEach((part) => {
+        part.object.updateMatrixWorld(true)
+        let bounds = new THREE.Box3().setFromObject(part.object)
+        const size = bounds.getSize(new THREE.Vector3())
+        if (x > 0 && x + size.x > maximumRowWidth + 1e-5) {
+            x = 0
+            z += rowDepth + printPlateGap
+            rowDepth = 0
+        }
+
+        part.object.position.x += x - bounds.min.x
+        part.object.position.z += z - bounds.min.z
+        part.object.updateMatrixWorld(true)
+        bounds = new THREE.Box3().setFromObject(part.object)
+        x = bounds.max.x + printPlateGap
+        rowDepth = Math.max(rowDepth, size.z)
+    })
+}
+
+function orientForPrinting(objects: THREE.Object3D[]): THREE.Group {
+    const group = new THREE.Group()
+    objects.forEach((object) => group.add(object))
+    group.rotation.x = Math.PI / 2
+    group.updateMatrixWorld(true)
+
+    const bounds = new THREE.Box3().setFromObject(group)
+    group.position.set(-bounds.min.x, -bounds.min.y, -bounds.min.z)
+    group.updateMatrixWorld(true)
+    return group
+}
+
+function exportBaseName(model: PrintableModel): string {
+    return `drawer-inserts-${model.totalWidth}x${model.totalDepth}x${model.wallHeight}`
+}
+
+function printPlateWidth(model: PrintableModel): number {
+    return (
+        model.totalWidth + printPlateGap * Math.max(0, model.grid[0].length - 1)
+    )
+}
+
+function archiveReadme(model: PrintableModel, uniqueCount: number): string {
+    return `# Box Grid Export
 
 This ZIP contains ${uniqueCount} unique box designs (_qtyN suffix shows multiples_).
+Designs are deduplicated by their generated mesh shape, including non-rectangular outlines.
 
 ## File Naming Convention
-- Regular boxes: box_[i]_[W]x[D]x[H]mm[_qtyN].stl  
-- Combined boxes: combined_box_[i]_[W]x[D]x[H]mm[_qtyN].stl  
+- Regular boxes: box_[i]_[W]x[D]x[H]mm[_qtyN].stl
+- Combined boxes: combined_box_[i]_[W]x[D]x[H]mm[_qtyN].stl
 
 ## Grid Layout
-- Grid size: ${cols}×${rows}  
-- Total width: ${state.totalWidth} mm  
-- Total depth: ${state.totalDepth} mm  
-- Box height: ${state.wallHeight} mm  
-- Wall thickness: ${state.wallThickness} mm  
+- Grid size: ${model.grid[0].length}×${model.grid.length}
+- Total width: ${model.totalWidth} mm
+- Total depth: ${model.totalDepth} mm
+- Box height: ${model.wallHeight} mm
+- Wall thickness: ${model.wallThickness} mm
 
 Thanks for using Box Grid Generator by timoweiss.me!
 Happy printing!
 `
-    zip.file('README.txt', readme)
+}
 
-    const content = await zip.generateAsync({ type: 'blob' })
+function download(
+    data: ArrayBuffer | Uint8Array,
+    filename: string,
+    contentType: string
+): void {
+    const blobData =
+        data instanceof Uint8Array ? new Uint8Array(data).buffer : data
+    const href = URL.createObjectURL(
+        new Blob([blobData], { type: contentType })
+    )
     const link = document.createElement('a')
-    link.href = URL.createObjectURL(content)
-    link.download = `drawer-inserts-${state.totalWidth}x${state.totalDepth}x${state.wallHeight}-grid.zip`
+    link.href = href
+    link.download = filename
     document.body.appendChild(link)
     link.click()
     document.body.removeChild(link)
-    setTimeout(() => URL.revokeObjectURL(link.href), 100)
-    disposeObject(boxGroup)
-}
-
-function removeHiddenObjects(object: THREE.Object3D): void {
-    for (const child of [...object.children]) {
-        if (!child.visible) {
-            object.remove(child)
-            continue
-        }
-
-        removeHiddenObjects(child)
-    }
+    setTimeout(() => URL.revokeObjectURL(href), 100)
 }

--- a/lib/exportWorker.ts
+++ b/lib/exportWorker.ts
@@ -1,0 +1,66 @@
+import type {
+    ExportWorkerRequest,
+    ExportWorkerResponse,
+} from '@/lib/exportProtocol'
+import { ExportModelError, validatePrintableModel } from '@/lib/printableModel'
+
+type WorkerMessenger = {
+    onmessage: ((event: MessageEvent<ExportWorkerRequest>) => void) | null
+    postMessage: (
+        message: ExportWorkerResponse,
+        transfer?: Transferable[]
+    ) => void
+}
+
+export async function processExportRequest(
+    { format, model }: ExportWorkerRequest,
+    send: WorkerMessenger['postMessage']
+): Promise<void> {
+    try {
+        progress(send, 5, 'Validating printable model…')
+        validatePrintableModel(model)
+        progress(send, 15, 'Generating watertight geometry…')
+
+        const exporters = await import('@/lib/exportUtils')
+        const output =
+            format === 'stl'
+                ? exporters.generateStl(model)
+                : format === '3mf'
+                  ? await exporters.generateThreeMf(model)
+                  : await exporters.generateSeparateStlZip(model)
+        progress(send, 95, 'Finalizing download…')
+
+        const buffer =
+            output instanceof Uint8Array
+                ? new Uint8Array(output).buffer
+                : output
+        send({ type: 'result', data: buffer }, [buffer])
+    } catch (error) {
+        send({
+            type: 'error',
+            name: error instanceof Error ? error.name : 'ExportError',
+            message:
+                error instanceof Error
+                    ? error.message
+                    : 'The export could not be generated.',
+            code: error instanceof ExportModelError ? error.code : undefined,
+        })
+    }
+}
+
+function progress(
+    send: WorkerMessenger['postMessage'],
+    percent: number,
+    message: string
+): void {
+    send({ type: 'progress', percent, message })
+}
+
+if (typeof self !== 'undefined') {
+    const workerScope = self as unknown as WorkerMessenger
+    workerScope.onmessage = ({ data }) => {
+        void processExportRequest(data, (message, transfer) =>
+            workerScope.postMessage(message, transfer)
+        )
+    }
+}

--- a/lib/lineHelper.ts
+++ b/lib/lineHelper.ts
@@ -224,22 +224,31 @@ export function offsetPolygonCCW(pts: THREE.Vector2[], t: number) {
     return inner
 }
 
-export function getRoundedOutline(
+export type RoundedOutlineGeometry = {
+    points: THREE.Vector2[]
+    corners: THREE.Vector2[][]
+}
+
+export function getRoundedOutlineGeometry(
     pts: THREE.Vector2[],
     radius: number,
     segmentsPerCorner = 5,
     corner_radius: number,
     wall_thickness: number
-): THREE.Vector2[] {
-    if (pts.length < 3 || (radius <= 0 && corner_radius <= 0))
-        return pts.slice()
-    const pointCount = pts.length
-    const rounded: THREE.Vector2[] = []
+): RoundedOutlineGeometry {
+    const outline = removeCollinearOutlinePoints(pts)
+    if (outline.length < 3) return { points: outline, corners: [] }
+    if (radius <= 0 && corner_radius <= 0) {
+        const corners = outline.map((point) => [point.clone()])
+        return { points: corners.flat(), corners }
+    }
+    const pointCount = outline.length
+    const corners: THREE.Vector2[][] = []
 
     for (let i = 0; i < pointCount; i++) {
-        const prev = pts[(i + pointCount - 1) % pointCount]
-        const curr = pts[i]
-        const next = pts[(i + 1) % pointCount]
+        const prev = outline[(i + pointCount - 1) % pointCount]
+        const curr = outline[i]
+        const next = outline[(i + 1) % pointCount]
 
         const previousEdge = curr.clone().sub(prev)
         const nextEdge = next.clone().sub(curr)
@@ -251,7 +260,7 @@ export function getRoundedOutline(
         const dNext = nextEdge.divideScalar(nextLength)
         const cross = dPrev.x * dNext.y - dPrev.y * dNext.x
         if (Math.abs(cross) <= 1e-10) {
-            pushUniquePoint(rounded, curr)
+            corners.push([curr.clone()])
             continue
         }
 
@@ -267,18 +276,19 @@ export function getRoundedOutline(
             nextLength / 2
         )
         if (r <= 1e-8) {
-            pushUniquePoint(rounded, curr)
+            corners.push([curr.clone()])
             continue
         }
 
         const pA = curr.clone().addScaledVector(dPrev, -r)
         const pB = curr.clone().addScaledVector(dNext, r)
-        pushUniquePoint(rounded, pA)
+        const corner: THREE.Vector2[] = []
+        pushUniquePoint(corner, pA)
         for (let segment = 1; segment <= segmentsPerCorner; segment++) {
             const t = segment / segmentsPerCorner
             const inverse = 1 - t
             pushUniquePoint(
-                rounded,
+                corner,
                 new THREE.Vector2(
                     inverse * inverse * pA.x +
                         2 * inverse * t * curr.x +
@@ -289,18 +299,46 @@ export function getRoundedOutline(
                 )
             )
         }
+        corners.push(corner)
     }
 
-    if (rounded.length > 1 && rounded[0].distanceTo(rounded.at(-1)!) <= 1e-8) {
-        rounded.pop()
-    }
-    return rounded
+    return { points: corners.flat(), corners }
+}
+
+export function getRoundedOutline(
+    pts: THREE.Vector2[],
+    radius: number,
+    segmentsPerCorner = 5,
+    corner_radius: number,
+    wall_thickness: number
+): THREE.Vector2[] {
+    return getRoundedOutlineGeometry(
+        pts,
+        radius,
+        segmentsPerCorner,
+        corner_radius,
+        wall_thickness
+    ).points
 }
 
 function pushUniquePoint(points: THREE.Vector2[], point: THREE.Vector2): void {
     const previous = points.at(-1)
     if (previous && previous.distanceTo(point) <= 1e-8) return
     points.push(point.clone())
+}
+
+function removeCollinearOutlinePoints(
+    points: THREE.Vector2[]
+): THREE.Vector2[] {
+    return points
+        .filter((current, index) => {
+            const previous = points[(index + points.length - 1) % points.length]
+            const next = points[(index + 1) % points.length]
+            const first = current.clone().sub(previous)
+            const second = next.clone().sub(current)
+            return Math.abs(first.x * second.y - first.y * second.x) > 1e-10
+        })
+        .map((point) => point.clone())
 }
 
 export function createCornerLines(

--- a/lib/lineHelper.ts
+++ b/lib/lineHelper.ts
@@ -231,41 +231,76 @@ export function getRoundedOutline(
     corner_radius: number,
     wall_thickness: number
 ): THREE.Vector2[] {
-    if (radius <= 0 || pts.length < 3) return pts.slice()
-    const N = pts.length
-    const path = new THREE.Path()
+    if (pts.length < 3 || (radius <= 0 && corner_radius <= 0))
+        return pts.slice()
+    const pointCount = pts.length
+    const rounded: THREE.Vector2[] = []
 
-    const prev0 = pts[N - 1]
-    const curr0 = pts[0]
-    const d0 = curr0.clone().sub(prev0).normalize()
-    path.moveTo(curr0.x - d0.x * radius, curr0.y - d0.y * radius)
-
-    for (let i = 0; i < N; i++) {
-        const prev = pts[(i + N - 1) % N]
+    for (let i = 0; i < pointCount; i++) {
+        const prev = pts[(i + pointCount - 1) % pointCount]
         const curr = pts[i]
-        const next = pts[(i + 1) % N]
+        const next = pts[(i + 1) % pointCount]
 
-        const dPrev = curr.clone().sub(prev).normalize()
-        const dNext = next.clone().sub(curr).normalize()
+        const previousEdge = curr.clone().sub(prev)
+        const nextEdge = next.clone().sub(curr)
+        const previousLength = previousEdge.length()
+        const nextLength = nextEdge.length()
+        if (previousLength === 0 || nextLength === 0) continue
+
+        const dPrev = previousEdge.divideScalar(previousLength)
+        const dNext = nextEdge.divideScalar(nextLength)
         const cross = dPrev.x * dNext.y - dPrev.y * dNext.x
-        const isConvex = cross >= 0
+        if (Math.abs(cross) <= 1e-10) {
+            pushUniquePoint(rounded, curr)
+            continue
+        }
 
-        const r = isConvex
-            ? radius
-            : radius === corner_radius
-              ? corner_radius - wall_thickness
-              : corner_radius
+        const requestedRadius =
+            cross > 0
+                ? radius
+                : radius === corner_radius
+                  ? corner_radius - wall_thickness
+                  : corner_radius
+        const r = Math.min(
+            Math.max(0, requestedRadius),
+            previousLength / 2,
+            nextLength / 2
+        )
+        if (r <= 1e-8) {
+            pushUniquePoint(rounded, curr)
+            continue
+        }
 
         const pA = curr.clone().addScaledVector(dPrev, -r)
         const pB = curr.clone().addScaledVector(dNext, r)
-
-        path.lineTo(pA.x, pA.y)
-        path.quadraticCurveTo(curr.x, curr.y, pB.x, pB.y)
+        pushUniquePoint(rounded, pA)
+        for (let segment = 1; segment <= segmentsPerCorner; segment++) {
+            const t = segment / segmentsPerCorner
+            const inverse = 1 - t
+            pushUniquePoint(
+                rounded,
+                new THREE.Vector2(
+                    inverse * inverse * pA.x +
+                        2 * inverse * t * curr.x +
+                        t * t * pB.x,
+                    inverse * inverse * pA.y +
+                        2 * inverse * t * curr.y +
+                        t * t * pB.y
+                )
+            )
+        }
     }
 
-    path.closePath()
-    const ptsOut = path.getPoints(N * segmentsPerCorner)
-    return ptsOut.map((p) => new THREE.Vector2(p.x, p.y))
+    if (rounded.length > 1 && rounded[0].distanceTo(rounded.at(-1)!) <= 1e-8) {
+        rounded.pop()
+    }
+    return rounded
+}
+
+function pushUniquePoint(points: THREE.Vector2[], point: THREE.Vector2): void {
+    const previous = points.at(-1)
+    if (previous && previous.distanceTo(point) <= 1e-8) return
+    points.push(point.clone())
 }
 
 export function createCornerLines(

--- a/lib/meshHelper.ts
+++ b/lib/meshHelper.ts
@@ -2,6 +2,7 @@ import { material } from '@/lib/defaults'
 import * as THREE from 'three'
 
 const coordinatePrecision = 1e6
+const geometryTolerance = 1e-7
 
 /**
  * Build one indexed, watertight box solid.
@@ -54,6 +55,11 @@ export function buildBoxMesh(
             vertex(c, cHeight),
         ]
         if (reverse) face.reverse()
+        if (new Set(face).size < 3) return
+
+        const ab = new THREE.Vector3(b.x - a.x, bHeight - aHeight, b.y - a.y)
+        const ac = new THREE.Vector3(c.x - a.x, cHeight - aHeight, c.y - a.y)
+        if (ab.cross(ac).lengthSq() <= geometryTolerance ** 2) return
         indices.push(...face)
     }
 
@@ -90,9 +96,87 @@ export function buildBoxMesh(
         })
     }
 
+    const ringSurface = (
+        outerLoop: THREE.Vector2[],
+        innerLoop: THREE.Vector2[],
+        height: number,
+        faceUp: boolean
+    ) => {
+        const outerProgress = loopProgress(outerLoop)
+        const innerProgress = loopProgress(innerLoop)
+        let outerIndex = 0
+        let innerIndex = 0
+
+        while (outerIndex < outerLoop.length || innerIndex < innerLoop.length) {
+            const outerCurrent = outerLoop[outerIndex % outerLoop.length]
+            const innerCurrent = innerLoop[innerIndex % innerLoop.length]
+            const nextOuterProgress =
+                outerIndex < outerLoop.length
+                    ? outerProgress[outerIndex + 1]
+                    : Infinity
+            const nextInnerProgress =
+                innerIndex < innerLoop.length
+                    ? innerProgress[innerIndex + 1]
+                    : Infinity
+
+            if (
+                Math.abs(nextOuterProgress - nextInnerProgress) <=
+                geometryTolerance
+            ) {
+                const outerNext = outerLoop[(outerIndex + 1) % outerLoop.length]
+                const innerNext = innerLoop[(innerIndex + 1) % innerLoop.length]
+                triangle(
+                    outerCurrent,
+                    height,
+                    outerNext,
+                    height,
+                    innerCurrent,
+                    height,
+                    faceUp
+                )
+                triangle(
+                    outerNext,
+                    height,
+                    innerNext,
+                    height,
+                    innerCurrent,
+                    height,
+                    faceUp
+                )
+                outerIndex++
+                innerIndex++
+            } else if (nextOuterProgress < nextInnerProgress) {
+                const outerNext = outerLoop[(outerIndex + 1) % outerLoop.length]
+                triangle(
+                    outerCurrent,
+                    height,
+                    outerNext,
+                    height,
+                    innerCurrent,
+                    height,
+                    faceUp
+                )
+                outerIndex++
+            } else {
+                const innerNext = innerLoop[(innerIndex + 1) % innerLoop.length]
+                triangle(
+                    outerCurrent,
+                    height,
+                    innerNext,
+                    height,
+                    innerCurrent,
+                    height,
+                    faceUp
+                )
+                innerIndex++
+            }
+        }
+    }
+
     const hasBottom = bottomThickness !== undefined && bottomThickness > 0
-    horizontalSurface(outer, hasBottom ? [] : [inner], 0, false)
-    horizontalSurface(outer, [inner], wallHeight, true)
+    if (hasBottom) horizontalSurface(outer, [], 0, false)
+    else ringSurface(outer, inner, 0, false)
+    ringSurface(outer, inner, wallHeight, true)
     if (hasBottom) horizontalSurface(inner, [], bottomThickness, true)
     sideSurface(outer, 0, wallHeight, false)
     sideSurface(inner, hasBottom ? bottomThickness : 0, wallHeight, true)
@@ -103,6 +187,7 @@ export function buildBoxMesh(
         new THREE.Float32BufferAttribute(positions, 3)
     )
     geometry.setIndex(indices)
+    validatePrintableGeometry(geometry)
     geometry.computeVertexNormals()
     geometry.computeBoundingBox()
     geometry.computeBoundingSphere()
@@ -116,13 +201,118 @@ export function buildBoxMesh(
     return new THREE.Mesh(geometry, boxMaterial)
 }
 
+function loopProgress(loop: THREE.Vector2[]): number[] {
+    const lengths = loop.map((point, index) =>
+        point.distanceTo(loop[(index + 1) % loop.length])
+    )
+    const total = lengths.reduce((sum, length) => sum + length, 0)
+    const progress = [0]
+    lengths.forEach((length) =>
+        progress.push(progress.at(-1)! + length / total)
+    )
+    progress[progress.length - 1] = 1
+    return progress
+}
+
+export function validatePrintableGeometry(
+    geometry: THREE.BufferGeometry
+): void {
+    const position = geometry.getAttribute('position')
+    const index = geometry.getIndex()
+    if (!position || !index || index.count === 0 || index.count % 3 !== 0) {
+        throw new Error('Printable mesh has no indexed triangle geometry.')
+    }
+
+    const edges = new Map<string, { count: number; balance: number }>()
+    let signedVolume = 0
+    for (let item = 0; item < index.count; item += 3) {
+        const vertexIndices = [
+            index.getX(item),
+            index.getX(item + 1),
+            index.getX(item + 2),
+        ]
+        const points = vertexIndices.map((vertexIndex) =>
+            new THREE.Vector3().fromBufferAttribute(position, vertexIndex)
+        )
+        if (points.some((point) => !point.toArray().every(Number.isFinite))) {
+            throw new Error('Printable mesh contains non-finite coordinates.')
+        }
+        if (
+            new THREE.Triangle(points[0], points[1], points[2]).getArea() <=
+            geometryTolerance
+        ) {
+            throw new Error('Printable mesh contains a degenerate triangle.')
+        }
+
+        signedVolume += points[0].dot(points[1].clone().cross(points[2])) / 6
+        ;[
+            [vertexIndices[0], vertexIndices[1]],
+            [vertexIndices[1], vertexIndices[2]],
+            [vertexIndices[2], vertexIndices[0]],
+        ].forEach(([a, b]) => {
+            const key = a < b ? `${a}:${b}` : `${b}:${a}`
+            const edge = edges.get(key) ?? { count: 0, balance: 0 }
+            edge.count++
+            edge.balance += a < b ? 1 : -1
+            edges.set(key, edge)
+        })
+    }
+
+    const invalidEdges = [...edges.entries()].filter(
+        ([, { count, balance }]) => count !== 2 || balance !== 0
+    )
+    const invalidEdgeCount = invalidEdges.length
+    if (invalidEdgeCount > 0) {
+        throw new Error(
+            `Printable mesh is open or non-manifold (${invalidEdgeCount} invalid edges: ${invalidEdges
+                .slice(0, 3)
+                .map(([key, edge]) => `${key}=${edge.count}/${edge.balance}`)
+                .join(', ')}).`
+        )
+    }
+    if (!(signedVolume > geometryTolerance)) {
+        throw new Error('Printable mesh has a non-positive signed volume.')
+    }
+}
+
 function normalizeLoop(points: THREE.Vector2[]): THREE.Vector2[] {
     const normalized: THREE.Vector2[] = []
     points.forEach((point) => {
-        if (!normalized.at(-1)?.equals(point)) normalized.push(point.clone())
+        if (!point.toArray().every(Number.isFinite)) {
+            throw new Error('Cannot build box geometry with non-finite points.')
+        }
+        const previous = normalized.at(-1)
+        if (!previous || previous.distanceTo(point) > geometryTolerance) {
+            normalized.push(point.clone())
+        }
     })
-    if (normalized.length > 1 && normalized[0].equals(normalized.at(-1)!)) {
+    if (
+        normalized.length > 1 &&
+        normalized[0].distanceTo(normalized.at(-1)!) <= geometryTolerance
+    ) {
         normalized.pop()
+    }
+
+    let changed = true
+    while (changed && normalized.length >= 3) {
+        changed = false
+        for (let index = 0; index < normalized.length; index++) {
+            const previous =
+                normalized[(index + normalized.length - 1) % normalized.length]
+            const current = normalized[index]
+            const next = normalized[(index + 1) % normalized.length]
+            const first = current.clone().sub(previous)
+            const second = next.clone().sub(current)
+            const cross = first.x * second.y - first.y * second.x
+            if (
+                Math.abs(cross) <= geometryTolerance &&
+                first.dot(second) >= 0
+            ) {
+                normalized.splice(index, 1)
+                changed = true
+                break
+            }
+        }
     }
     return normalized
 }

--- a/lib/meshHelper.ts
+++ b/lib/meshHelper.ts
@@ -1,65 +1,128 @@
 import { material } from '@/lib/defaults'
 import * as THREE from 'three'
 
-export function buildWallMesh(
-    outerPts: THREE.Vector2[],
-    innerPts: THREE.Vector2[],
-    wallHeight: number
+const coordinatePrecision = 1e6
+
+/**
+ * Build one indexed, watertight box solid.
+ *
+ * A bottomed box is deliberately not represented as an overlapping wall ring
+ * and slab. Its underside, outside wall, inside wall, cavity floor, and rim are
+ * stitched into one boundary so every mesh edge belongs to exactly two faces.
+ */
+export function buildBoxMesh(
+    outerPoints: THREE.Vector2[],
+    innerPoints: THREE.Vector2[],
+    wallHeight: number,
+    bottomThickness?: number
 ): THREE.Mesh {
-    const shape = new THREE.Shape()
-    if (outerPts.length) {
-        shape.moveTo(outerPts[0].x, outerPts[0].y)
-        outerPts.slice(1).forEach((pt) => shape.lineTo(pt.x, pt.y))
-        shape.closePath()
+    const outer = normalizeLoop(outerPoints)
+    const inner = normalizeLoop(innerPoints)
+    if (outer.length < 3 || inner.length < 3) {
+        throw new Error('Cannot build box geometry from an invalid outline.')
     }
 
-    if (innerPts.length) {
-        const hole = new THREE.Path()
-        hole.moveTo(innerPts[0].x, innerPts[0].y)
-        innerPts.slice(1).forEach((pt) => hole.lineTo(pt.x, pt.y))
-        hole.closePath()
-        shape.holes.push(hole)
+    const positions: number[] = []
+    const indices: number[] = []
+    const vertices = new Map<string, number>()
+
+    const vertex = (point: THREE.Vector2, height: number): number => {
+        const key = [point.x, height, point.y]
+            .map((value) => Math.round(value * coordinatePrecision))
+            .join(':')
+        const existing = vertices.get(key)
+        if (existing !== undefined) return existing
+
+        const index = positions.length / 3
+        positions.push(point.x, height, point.y)
+        vertices.set(key, index)
+        return index
     }
 
-    const geo = new THREE.ExtrudeGeometry(shape, {
-        steps: 1,
-        depth: wallHeight,
-        bevelEnabled: false,
-    })
-    geo.rotateX(Math.PI / 2)
-    geo.translate(0, wallHeight, 0)
+    const triangle = (
+        a: THREE.Vector2,
+        aHeight: number,
+        b: THREE.Vector2,
+        bHeight: number,
+        c: THREE.Vector2,
+        cHeight: number,
+        reverse = false
+    ) => {
+        const face = [
+            vertex(a, aHeight),
+            vertex(b, bHeight),
+            vertex(c, cHeight),
+        ]
+        if (reverse) face.reverse()
+        indices.push(...face)
+    }
 
-    const mat = new THREE.MeshStandardMaterial({
+    const horizontalSurface = (
+        contour: THREE.Vector2[],
+        holes: THREE.Vector2[][],
+        height: number,
+        faceUp: boolean
+    ) => {
+        const points = [...contour, ...holes.flat()]
+        THREE.ShapeUtils.triangulateShape(contour, holes).forEach(([a, b, c]) =>
+            triangle(
+                points[a],
+                height,
+                points[b],
+                height,
+                points[c],
+                height,
+                faceUp
+            )
+        )
+    }
+
+    const sideSurface = (
+        loop: THREE.Vector2[],
+        bottom: number,
+        top: number,
+        faceInward: boolean
+    ) => {
+        loop.forEach((current, index) => {
+            const next = loop[(index + 1) % loop.length]
+            triangle(current, bottom, current, top, next, top, faceInward)
+            triangle(current, bottom, next, top, next, bottom, faceInward)
+        })
+    }
+
+    const hasBottom = bottomThickness !== undefined && bottomThickness > 0
+    horizontalSurface(outer, hasBottom ? [] : [inner], 0, false)
+    horizontalSurface(outer, [inner], wallHeight, true)
+    if (hasBottom) horizontalSurface(inner, [], bottomThickness, true)
+    sideSurface(outer, 0, wallHeight, false)
+    sideSurface(inner, hasBottom ? bottomThickness : 0, wallHeight, true)
+
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+        'position',
+        new THREE.Float32BufferAttribute(positions, 3)
+    )
+    geometry.setIndex(indices)
+    geometry.computeVertexNormals()
+    geometry.computeBoundingBox()
+    geometry.computeBoundingSphere()
+
+    const boxMaterial = new THREE.MeshStandardMaterial({
         color: material.standard.color,
         roughness: material.standard.roughness,
         metalness: material.standard.metalness,
         side: THREE.DoubleSide,
     })
-    return new THREE.Mesh(geo, mat)
+    return new THREE.Mesh(geometry, boxMaterial)
 }
 
-export function buildBottomMesh(
-    outerPts: THREE.Vector2[],
-    thickness: number
-): THREE.Mesh {
-    const shape = new THREE.Shape()
-    shape.moveTo(outerPts[0].x, outerPts[0].y)
-    outerPts.slice(1).forEach((pt) => shape.lineTo(pt.x, pt.y))
-    shape.closePath()
-
-    const geo = new THREE.ExtrudeGeometry(shape, {
-        steps: 1,
-        depth: thickness,
-        bevelEnabled: false,
+function normalizeLoop(points: THREE.Vector2[]): THREE.Vector2[] {
+    const normalized: THREE.Vector2[] = []
+    points.forEach((point) => {
+        if (!normalized.at(-1)?.equals(point)) normalized.push(point.clone())
     })
-    geo.rotateX(Math.PI / 2)
-    geo.translate(0, thickness, 0)
-
-    const mat = new THREE.MeshStandardMaterial({
-        color: material.standard.color,
-        roughness: material.standard.roughness,
-        metalness: material.standard.metalness,
-        side: THREE.DoubleSide,
-    })
-    return new THREE.Mesh(geo, mat)
+    if (normalized.length > 1 && normalized[0].equals(normalized.at(-1)!)) {
+        normalized.pop()
+    }
+    return normalized
 }

--- a/lib/meshHelper.ts
+++ b/lib/meshHelper.ts
@@ -1,4 +1,5 @@
 import { material } from '@/lib/defaults'
+import type { RoundedOutlineGeometry } from '@/lib/lineHelper'
 import * as THREE from 'three'
 
 const coordinatePrecision = 1e6
@@ -12,13 +13,13 @@ const geometryTolerance = 1e-7
  * stitched into one boundary so every mesh edge belongs to exactly two faces.
  */
 export function buildBoxMesh(
-    outerPoints: THREE.Vector2[],
-    innerPoints: THREE.Vector2[],
+    outerOutline: RoundedOutlineGeometry,
+    innerOutline: RoundedOutlineGeometry,
     wallHeight: number,
     bottomThickness?: number
 ): THREE.Mesh {
-    const outer = normalizeLoop(outerPoints)
-    const inner = normalizeLoop(innerPoints)
+    const outer = normalizeLoop(outerOutline.points)
+    const inner = normalizeLoop(innerOutline.points)
     if (outer.length < 3 || inner.length < 3) {
         throw new Error('Cannot build box geometry from an invalid outline.')
     }
@@ -55,28 +56,32 @@ export function buildBoxMesh(
             vertex(c, cHeight),
         ]
         if (reverse) face.reverse()
-        if (new Set(face).size < 3) return
+        if (new Set(face).size < 3) {
+            throw new Error('Printable mesh triangulation collapsed a face.')
+        }
 
         const ab = new THREE.Vector3(b.x - a.x, bHeight - aHeight, b.y - a.y)
         const ac = new THREE.Vector3(c.x - a.x, cHeight - aHeight, c.y - a.y)
-        if (ab.cross(ac).lengthSq() <= geometryTolerance ** 2) return
+        if (ab.cross(ac).lengthSq() <= geometryTolerance ** 2) {
+            throw new Error(
+                'Printable mesh triangulation produced a degenerate face.'
+            )
+        }
         indices.push(...face)
     }
 
     const horizontalSurface = (
         contour: THREE.Vector2[],
-        holes: THREE.Vector2[][],
         height: number,
         faceUp: boolean
     ) => {
-        const points = [...contour, ...holes.flat()]
-        THREE.ShapeUtils.triangulateShape(contour, holes).forEach(([a, b, c]) =>
+        triangulateSimplePolygon(contour).forEach(([a, b, c]) =>
             triangle(
-                points[a],
+                contour[a],
                 height,
-                points[b],
+                contour[b],
                 height,
-                points[c],
+                contour[c],
                 height,
                 faceUp
             )
@@ -89,6 +94,7 @@ export function buildBoxMesh(
         top: number,
         faceInward: boolean
     ) => {
+        if (Math.abs(top - bottom) <= geometryTolerance) return
         loop.forEach((current, index) => {
             const next = loop[(index + 1) % loop.length]
             triangle(current, bottom, current, top, next, top, faceInward)
@@ -97,87 +103,104 @@ export function buildBoxMesh(
     }
 
     const ringSurface = (
-        outerLoop: THREE.Vector2[],
-        innerLoop: THREE.Vector2[],
+        outerCorners: THREE.Vector2[][],
+        innerCorners: THREE.Vector2[][],
         height: number,
         faceUp: boolean
     ) => {
-        const outerProgress = loopProgress(outerLoop)
-        const innerProgress = loopProgress(innerLoop)
-        let outerIndex = 0
-        let innerIndex = 0
-
-        while (outerIndex < outerLoop.length || innerIndex < innerLoop.length) {
-            const outerCurrent = outerLoop[outerIndex % outerLoop.length]
-            const innerCurrent = innerLoop[innerIndex % innerLoop.length]
-            const nextOuterProgress =
-                outerIndex < outerLoop.length
-                    ? outerProgress[outerIndex + 1]
-                    : Infinity
-            const nextInnerProgress =
-                innerIndex < innerLoop.length
-                    ? innerProgress[innerIndex + 1]
-                    : Infinity
-
-            if (
-                Math.abs(nextOuterProgress - nextInnerProgress) <=
-                geometryTolerance
-            ) {
-                const outerNext = outerLoop[(outerIndex + 1) % outerLoop.length]
-                const innerNext = innerLoop[(innerIndex + 1) % innerLoop.length]
-                triangle(
-                    outerCurrent,
-                    height,
-                    outerNext,
-                    height,
-                    innerCurrent,
-                    height,
-                    faceUp
-                )
-                triangle(
-                    outerNext,
-                    height,
-                    innerNext,
-                    height,
-                    innerCurrent,
-                    height,
-                    faceUp
-                )
-                outerIndex++
-                innerIndex++
-            } else if (nextOuterProgress < nextInnerProgress) {
-                const outerNext = outerLoop[(outerIndex + 1) % outerLoop.length]
-                triangle(
-                    outerCurrent,
-                    height,
-                    outerNext,
-                    height,
-                    innerCurrent,
-                    height,
-                    faceUp
-                )
-                outerIndex++
-            } else {
-                const innerNext = innerLoop[(innerIndex + 1) % innerLoop.length]
-                triangle(
-                    outerCurrent,
-                    height,
-                    innerNext,
-                    height,
-                    innerCurrent,
-                    height,
-                    faceUp
-                )
-                innerIndex++
-            }
+        if (outerCorners.length !== innerCorners.length) {
+            throw new Error('Printable mesh outlines have mismatched corners.')
         }
+
+        outerCorners.forEach((outerCorner, cornerIndex) => {
+            const innerCorner = innerCorners[cornerIndex]
+            if (outerCorner.length === 1) {
+                for (let index = 0; index < innerCorner.length - 1; index++) {
+                    triangle(
+                        outerCorner[0],
+                        height,
+                        innerCorner[index + 1],
+                        height,
+                        innerCorner[index],
+                        height,
+                        faceUp
+                    )
+                }
+            } else if (innerCorner.length === 1) {
+                for (let index = 0; index < outerCorner.length - 1; index++) {
+                    triangle(
+                        outerCorner[index],
+                        height,
+                        outerCorner[index + 1],
+                        height,
+                        innerCorner[0],
+                        height,
+                        faceUp
+                    )
+                }
+            } else {
+                if (outerCorner.length !== innerCorner.length) {
+                    throw new Error(
+                        'Printable mesh rounded corners have mismatched samples.'
+                    )
+                }
+                for (let index = 0; index < outerCorner.length - 1; index++) {
+                    const outerCurrent = outerCorner[index]
+                    const outerNext = outerCorner[index + 1]
+                    const innerCurrent = innerCorner[index]
+                    const innerNext = innerCorner[index + 1]
+                    triangle(
+                        outerCurrent,
+                        height,
+                        outerNext,
+                        height,
+                        innerCurrent,
+                        height,
+                        faceUp
+                    )
+                    triangle(
+                        outerNext,
+                        height,
+                        innerNext,
+                        height,
+                        innerCurrent,
+                        height,
+                        faceUp
+                    )
+                }
+            }
+
+            const nextCorner = (cornerIndex + 1) % outerCorners.length
+            const outerCurrent = outerCorner.at(-1)!
+            const outerNext = outerCorners[nextCorner][0]
+            const innerCurrent = innerCorner.at(-1)!
+            const innerNext = innerCorners[nextCorner][0]
+            triangle(
+                outerCurrent,
+                height,
+                outerNext,
+                height,
+                innerCurrent,
+                height,
+                faceUp
+            )
+            triangle(
+                outerNext,
+                height,
+                innerNext,
+                height,
+                innerCurrent,
+                height,
+                faceUp
+            )
+        })
     }
 
     const hasBottom = bottomThickness !== undefined && bottomThickness > 0
-    if (hasBottom) horizontalSurface(outer, [], 0, false)
-    else ringSurface(outer, inner, 0, false)
-    ringSurface(outer, inner, wallHeight, true)
-    if (hasBottom) horizontalSurface(inner, [], bottomThickness, true)
+    if (hasBottom) horizontalSurface(outer, 0, false)
+    else ringSurface(outerOutline.corners, innerOutline.corners, 0, false)
+    ringSurface(outerOutline.corners, innerOutline.corners, wallHeight, true)
+    if (hasBottom) horizontalSurface(inner, bottomThickness, true)
     sideSurface(outer, 0, wallHeight, false)
     sideSurface(inner, hasBottom ? bottomThickness : 0, wallHeight, true)
 
@@ -199,19 +222,6 @@ export function buildBoxMesh(
         side: THREE.DoubleSide,
     })
     return new THREE.Mesh(geometry, boxMaterial)
-}
-
-function loopProgress(loop: THREE.Vector2[]): number[] {
-    const lengths = loop.map((point, index) =>
-        point.distanceTo(loop[(index + 1) % loop.length])
-    )
-    const total = lengths.reduce((sum, length) => sum + length, 0)
-    const progress = [0]
-    lengths.forEach((length) =>
-        progress.push(progress.at(-1)! + length / total)
-    )
-    progress[progress.length - 1] = 1
-    return progress
 }
 
 export function validatePrintableGeometry(
@@ -315,4 +325,148 @@ function normalizeLoop(points: THREE.Vector2[]): THREE.Vector2[] {
         }
     }
     return normalized
+}
+
+/**
+ * Triangulate one validated, hole-free outline while retaining its boundary
+ * vertices. Three.js delegates this case to Earcut, which can choose a
+ * zero-area ear when a concave orthogonal outline and its rounded samples line
+ * up. A local ear clipper can reject those ears without dropping any boundary
+ * edge, keeping the horizontal faces stitched to the side walls.
+ */
+function triangulateSimplePolygon(
+    points: THREE.Vector2[]
+): [number, number, number][] {
+    if (points.length < 3) {
+        throw new Error(
+            'Cannot triangulate a printable face with fewer than 3 points.'
+        )
+    }
+
+    const order = points.map((_, index) => index)
+    if (signedArea(points) < 0) order.reverse()
+
+    const previous: number[] = []
+    const next: number[] = []
+    const active = points.map(() => true)
+    order.forEach((index, position) => {
+        previous[index] = order[(position + order.length - 1) % order.length]
+        next[index] = order[(position + 1) % order.length]
+    })
+
+    const isEar = (currentIndex: number): boolean => {
+        if (!active[currentIndex]) return false
+
+        const previousIndex = previous[currentIndex]
+        const nextIndex = next[currentIndex]
+        const previousPoint = points[previousIndex]
+        const currentPoint = points[currentIndex]
+        const nextPoint = points[nextIndex]
+        if (
+            cross2d(previousPoint, currentPoint, nextPoint) <=
+            geometryTolerance * 2
+        ) {
+            return false
+        }
+
+        return !active.some(
+            (isActive, candidateIndex) =>
+                isActive &&
+                candidateIndex !== previousIndex &&
+                candidateIndex !== currentIndex &&
+                candidateIndex !== nextIndex &&
+                pointInOrOnTriangle(
+                    points[candidateIndex],
+                    previousPoint,
+                    currentPoint,
+                    nextPoint
+                )
+        )
+    }
+
+    const ears = new Set(order.filter(isEar))
+    const refreshEar = (index: number) => {
+        ears.delete(index)
+        if (isEar(index)) ears.add(index)
+    }
+
+    const triangles: [number, number, number][] = []
+    let remainingCount = points.length
+    while (remainingCount > 3) {
+        if (ears.size === 0) {
+            active.forEach((isActive, index) => {
+                if (isActive && isEar(index)) ears.add(index)
+            })
+        }
+        if (ears.size === 0) {
+            throw new Error(
+                'Printable mesh face could not be triangulated without degenerate triangles.'
+            )
+        }
+
+        let currentIndex = -1
+        let bestEarArea = -Infinity
+        ears.forEach((candidateIndex) => {
+            const area = cross2d(
+                points[previous[candidateIndex]],
+                points[candidateIndex],
+                points[next[candidateIndex]]
+            )
+            if (area > bestEarArea) {
+                bestEarArea = area
+                currentIndex = candidateIndex
+            }
+        })
+
+        const previousIndex = previous[currentIndex]
+        const nextIndex = next[currentIndex]
+        triangles.push([previousIndex, currentIndex, nextIndex])
+        active[currentIndex] = false
+        remainingCount--
+        ears.delete(currentIndex)
+        next[previousIndex] = nextIndex
+        previous[nextIndex] = previousIndex
+        refreshEar(previousIndex)
+        refreshEar(nextIndex)
+    }
+
+    const first = active.findIndex(Boolean)
+    const remaining = [first, next[first], next[next[first]]]
+
+    if (
+        cross2d(
+            points[remaining[0]],
+            points[remaining[1]],
+            points[remaining[2]]
+        ) <=
+        geometryTolerance * 2
+    ) {
+        throw new Error('Printable mesh face ended with a degenerate triangle.')
+    }
+    triangles.push([remaining[0], remaining[1], remaining[2]])
+    return triangles
+}
+
+function signedArea(points: THREE.Vector2[]): number {
+    return points.reduce((area, point, index) => {
+        const next = points[(index + 1) % points.length]
+        return area + point.x * next.y - next.x * point.y
+    }, 0)
+}
+
+function cross2d(a: THREE.Vector2, b: THREE.Vector2, c: THREE.Vector2): number {
+    return (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x)
+}
+
+function pointInOrOnTriangle(
+    point: THREE.Vector2,
+    a: THREE.Vector2,
+    b: THREE.Vector2,
+    c: THREE.Vector2
+): boolean {
+    return (
+        cross2d(a, b, point) >= -geometryTolerance &&
+        cross2d(b, c, point) >= -geometryTolerance &&
+        cross2d(c, a, point) >= -geometryTolerance
+    )
 }

--- a/lib/printableModel.ts
+++ b/lib/printableModel.ts
@@ -1,0 +1,182 @@
+import { generateCustomBox } from '@/lib/boxHelper'
+import { getGridBoxes } from '@/lib/gridVisibility'
+import { disposeObject } from '@/lib/threeDisposal'
+import type {
+    GeneratedBoxMetadata,
+    Grid,
+    ModelConfig,
+    StoreState,
+} from '@/lib/types'
+import * as THREE from 'three'
+
+export type PrintableModel = Pick<
+    ModelConfig,
+    | 'totalWidth'
+    | 'totalDepth'
+    | 'wallThickness'
+    | 'cornerRadius'
+    | 'wallHeight'
+    | 'generateBottom'
+> & { grid: Grid }
+
+export type PrintablePart = {
+    metadata: GeneratedBoxMetadata
+    object: THREE.Object3D
+    shapeSignature: string
+}
+
+export type PrintablePartGroup = {
+    representative: PrintablePart
+    count: number
+}
+
+/** Capture an immutable domain snapshot before an asynchronous export starts. */
+export function snapshotPrintableModel(state: StoreState): PrintableModel {
+    return {
+        totalWidth: state.totalWidth,
+        totalDepth: state.totalDepth,
+        wallThickness: state.wallThickness,
+        cornerRadius: state.cornerRadius,
+        wallHeight: state.wallHeight,
+        generateBottom: state.generateBottom,
+        grid: state.grid.map((row) => row.map((cell) => ({ ...cell }))),
+    }
+}
+
+/**
+ * Generate export parts directly from domain data. Scene helpers, selection
+ * materials, cameras, and the currently rendered Three.js scene are not read.
+ */
+export function buildPrintableParts(model: PrintableModel): PrintablePart[] {
+    if (model.grid.length === 0) return []
+
+    const generated = generateCustomBox(model.grid, {
+        wallThickness: model.wallThickness,
+        cornerRadius: model.cornerRadius,
+        wallHeight: model.wallHeight,
+        generateBottom: model.generateBottom,
+        cornerLines: { show: false, color: 0, opacity: 0 },
+    })
+    const metadataById = new Map(
+        getGridBoxes(model.grid, model.wallHeight).map((entry) => [
+            entry.id,
+            entry,
+        ])
+    )
+    const parts: PrintablePart[] = []
+
+    for (const object of [...generated.children]) {
+        generated.remove(object)
+        const metadata = metadataById.get(
+            object.name as GeneratedBoxMetadata['id']
+        )
+        if (!metadata || metadata.visibility === 'hidden') {
+            disposeObject(object)
+            continue
+        }
+
+        parts.push({
+            metadata,
+            object,
+            shapeSignature: createShapeSignature(model, metadata),
+        })
+    }
+
+    return parts
+}
+
+/** Group rotationally equivalent meshes while keeping distinct footprints. */
+export function groupPrintableParts(
+    parts: PrintablePart[]
+): PrintablePartGroup[] {
+    const groups = new Map<string, PrintablePartGroup>()
+    parts.forEach((part) => {
+        const group = groups.get(part.shapeSignature)
+        if (group) group.count++
+        else groups.set(part.shapeSignature, { representative: part, count: 1 })
+    })
+    return [...groups.values()]
+}
+
+/**
+ * Canonicalize the physical cell footprint and every mesh-affecting option
+ * under quarter turns around the print axis. Translation and a width/depth swap
+ * do not create a new design; different outlines with the same bounds do.
+ */
+export function createShapeSignature(
+    model: PrintableModel,
+    metadata: GeneratedBoxMetadata
+): string {
+    const cumulativeWidths = cumulative(model.grid[0].map((cell) => cell.width))
+    const cumulativeDepths = cumulative(model.grid.map((row) => row[0].depth))
+    const rectangles = metadata.cells.map(({ x, z }) => [
+        [cumulativeWidths[x], cumulativeDepths[z]],
+        [cumulativeWidths[x + 1], cumulativeDepths[z + 1]],
+    ])
+    const footprint = Array.from({ length: 4 }, (_, turns) => {
+        const rotated = rectangles.map(([minimum, maximum]) => {
+            const corners = [
+                rotateQuarterTurn(minimum[0], minimum[1], turns),
+                rotateQuarterTurn(maximum[0], minimum[1], turns),
+                rotateQuarterTurn(maximum[0], maximum[1], turns),
+                rotateQuarterTurn(minimum[0], maximum[1], turns),
+            ]
+            return [
+                Math.min(...corners.map(([x]) => x)),
+                Math.min(...corners.map(([, z]) => z)),
+                Math.max(...corners.map(([x]) => x)),
+                Math.max(...corners.map(([, z]) => z)),
+            ]
+        })
+        const minimumX = Math.min(...rotated.map(([x]) => x))
+        const minimumZ = Math.min(...rotated.map(([, z]) => z))
+        return rotated
+            .map(([x1, z1, x2, z2]) =>
+                [x1 - minimumX, z1 - minimumZ, x2 - minimumX, z2 - minimumZ]
+                    .map(quantize)
+                    .join(',')
+            )
+            .sort()
+            .join(';')
+    }).sort()[0]
+    const options = [
+        model.wallThickness,
+        model.cornerRadius,
+        model.wallHeight,
+        model.generateBottom ? 1 : 0,
+    ]
+        .map(quantize)
+        .join('|')
+    return `${options}|${footprint}`
+}
+
+function cumulative(values: number[]): number[] {
+    return values.reduce<number[]>(
+        (result, value) => {
+            result.push(result.at(-1)! + value)
+            return result
+        },
+        [0]
+    )
+}
+
+function rotateQuarterTurn(
+    x: number,
+    z: number,
+    turns: number
+): [number, number] {
+    switch (turns) {
+        case 1:
+            return [-z, x]
+        case 2:
+            return [-x, -z]
+        case 3:
+            return [z, -x]
+        default:
+            return [x, z]
+    }
+}
+
+function quantize(value: number): string {
+    return (Math.round(value * 1e5) / 1e5).toFixed(5)
+}

--- a/lib/printableModel.ts
+++ b/lib/printableModel.ts
@@ -1,5 +1,6 @@
 import { generateCustomBox } from '@/lib/boxHelper'
 import { getGridBoxes } from '@/lib/gridVisibility'
+import { getOutline } from '@/lib/lineHelper'
 import { disposeObject } from '@/lib/threeDisposal'
 import type {
     GeneratedBoxMetadata,
@@ -30,6 +31,26 @@ export type PrintablePartGroup = {
     count: number
 }
 
+export const exportLimits = {
+    maxCells: 2_500,
+    maxVisibleParts: 250,
+    maxOutputBytes: 32 * 1024 * 1024,
+    workerMemoryBudgetBytes: 128 * 1024 * 1024,
+} as const
+
+export type ExportModelErrorCode =
+    'no-visible-parts' | 'cell-limit' | 'part-limit' | 'output-limit'
+
+export class ExportModelError extends Error {
+    constructor(
+        readonly code: ExportModelErrorCode,
+        message: string
+    ) {
+        super(message)
+        this.name = 'ExportModelError'
+    }
+}
+
 /** Capture an immutable domain snapshot before an asynchronous export starts. */
 export function snapshotPrintableModel(state: StoreState): PrintableModel {
     return {
@@ -48,13 +69,14 @@ export function snapshotPrintableModel(state: StoreState): PrintableModel {
  * materials, cameras, and the currently rendered Three.js scene are not read.
  */
 export function buildPrintableParts(model: PrintableModel): PrintablePart[] {
-    if (model.grid.length === 0) return []
+    validatePrintableModel(model)
 
     const generated = generateCustomBox(model.grid, {
         wallThickness: model.wallThickness,
         cornerRadius: model.cornerRadius,
         wallHeight: model.wallHeight,
         generateBottom: model.generateBottom,
+        includeHidden: false,
         cornerLines: { show: false, color: 0, opacity: 0 },
     })
     const metadataById = new Map(
@@ -85,6 +107,32 @@ export function buildPrintableParts(model: PrintableModel): PrintablePart[] {
     return parts
 }
 
+export function validatePrintableModel(model: PrintableModel): void {
+    const cellCount = model.grid.reduce((sum, row) => sum + row.length, 0)
+    if (cellCount > exportLimits.maxCells) {
+        throw new ExportModelError(
+            'cell-limit',
+            `This model has ${cellCount.toLocaleString()} cells; exports support up to ${exportLimits.maxCells.toLocaleString()}. Reduce the grid density before exporting.`
+        )
+    }
+
+    const visibleParts = getGridBoxes(model.grid, model.wallHeight).filter(
+        (part) => part.visibility === 'visible'
+    ).length
+    if (visibleParts === 0) {
+        throw new ExportModelError(
+            'no-visible-parts',
+            'There are no visible boxes to export.'
+        )
+    }
+    if (visibleParts > exportLimits.maxVisibleParts) {
+        throw new ExportModelError(
+            'part-limit',
+            `This model has ${visibleParts.toLocaleString()} visible boxes; exports support up to ${exportLimits.maxVisibleParts.toLocaleString()}. Combine or hide boxes before exporting.`
+        )
+    }
+}
+
 /** Group rotationally equivalent meshes while keeping distinct footprints. */
 export function groupPrintableParts(
     parts: PrintablePart[]
@@ -99,9 +147,9 @@ export function groupPrintableParts(
 }
 
 /**
- * Canonicalize the physical cell footprint and every mesh-affecting option
- * under quarter turns around the print axis. Translation and a width/depth swap
- * do not create a new design; different outlines with the same bounds do.
+ * Canonicalize the union boundary and every mesh-affecting option under quarter
+ * turns around the print axis. Collinear cell seams are removed, so equivalent
+ * designs deduplicate regardless of how their source grid was partitioned.
  */
 export function createShapeSignature(
     model: PrintableModel,
@@ -109,35 +157,41 @@ export function createShapeSignature(
 ): string {
     const cumulativeWidths = cumulative(model.grid[0].map((cell) => cell.width))
     const cumulativeDepths = cumulative(model.grid.map((row) => row[0].depth))
-    const rectangles = metadata.cells.map(({ x, z }) => [
-        [cumulativeWidths[x], cumulativeDepths[z]],
-        [cumulativeWidths[x + 1], cumulativeDepths[z + 1]],
-    ])
+    const rawOutline = metadata.isCombined
+        ? getOutline(model.grid, metadata.group)
+        : [
+              new THREE.Vector2(
+                  cumulativeWidths[metadata.cells[0].x],
+                  cumulativeDepths[metadata.cells[0].z]
+              ),
+              new THREE.Vector2(
+                  cumulativeWidths[metadata.cells[0].x + 1],
+                  cumulativeDepths[metadata.cells[0].z]
+              ),
+              new THREE.Vector2(
+                  cumulativeWidths[metadata.cells[0].x + 1],
+                  cumulativeDepths[metadata.cells[0].z + 1]
+              ),
+              new THREE.Vector2(
+                  cumulativeWidths[metadata.cells[0].x],
+                  cumulativeDepths[metadata.cells[0].z + 1]
+              ),
+          ]
+    const outline = removeCollinearPoints(rawOutline)
     const footprint = Array.from({ length: 4 }, (_, turns) => {
-        const rotated = rectangles.map(([minimum, maximum]) => {
-            const corners = [
-                rotateQuarterTurn(minimum[0], minimum[1], turns),
-                rotateQuarterTurn(maximum[0], minimum[1], turns),
-                rotateQuarterTurn(maximum[0], maximum[1], turns),
-                rotateQuarterTurn(minimum[0], maximum[1], turns),
-            ]
-            return [
-                Math.min(...corners.map(([x]) => x)),
-                Math.min(...corners.map(([, z]) => z)),
-                Math.max(...corners.map(([x]) => x)),
-                Math.max(...corners.map(([, z]) => z)),
-            ]
-        })
+        const rotated = outline.map((point) =>
+            rotateQuarterTurn(point.x, point.y, turns)
+        )
         const minimumX = Math.min(...rotated.map(([x]) => x))
         const minimumZ = Math.min(...rotated.map(([, z]) => z))
-        return rotated
-            .map(([x1, z1, x2, z2]) =>
-                [x1 - minimumX, z1 - minimumZ, x2 - minimumX, z2 - minimumZ]
-                    .map(quantize)
-                    .join(',')
+        const points = rotated.map(([x, z]) =>
+            [x - minimumX, z - minimumZ].map(quantize).join(',')
+        )
+        return points
+            .map((_, start) =>
+                [...points.slice(start), ...points.slice(0, start)].join(';')
             )
-            .sort()
-            .join(';')
+            .sort()[0]
     }).sort()[0]
     const options = [
         model.wallThickness,
@@ -148,6 +202,16 @@ export function createShapeSignature(
         .map(quantize)
         .join('|')
     return `${options}|${footprint}`
+}
+
+function removeCollinearPoints(points: THREE.Vector2[]): THREE.Vector2[] {
+    return points.filter((current, index) => {
+        const previous = points[(index + points.length - 1) % points.length]
+        const next = points[(index + 1) % points.length]
+        const first = current.clone().sub(previous)
+        const second = next.clone().sub(current)
+        return Math.abs(first.x * second.y - first.y * second.x) > 1e-8
+    })
 }
 
 function cumulative(values: number[]): number[] {

--- a/lib/threeMfExporter.ts
+++ b/lib/threeMfExporter.ts
@@ -1,0 +1,124 @@
+import JSZip from 'jszip'
+import * as THREE from 'three'
+
+type ThreeMfMesh = {
+    vertices: THREE.Vector3[]
+    triangles: [number, number, number][]
+}
+
+/** Serialize printable meshes as a standards-based 3MF OPC package. */
+export async function exportThreeMf(
+    object: THREE.Object3D,
+    title: string
+): Promise<Uint8Array> {
+    object.updateMatrixWorld(true)
+    const meshes = collectMeshes(object)
+    if (meshes.length === 0)
+        throw new Error('Cannot export an empty 3MF model.')
+
+    const resources = meshes
+        .map(
+            (mesh, index) => `
+        <object id="${index + 1}" type="model">
+            <mesh>
+                <vertices>
+${mesh.vertices
+    .map(
+        (vertex) =>
+            `                    <vertex x="${number(vertex.x)}" y="${number(vertex.y)}" z="${number(vertex.z)}"/>`
+    )
+    .join('\n')}
+                </vertices>
+                <triangles>
+${mesh.triangles
+    .map(
+        ([v1, v2, v3]) =>
+            `                    <triangle v1="${v1}" v2="${v2}" v3="${v3}"/>`
+    )
+    .join('\n')}
+                </triangles>
+            </mesh>
+        </object>`
+        )
+        .join('')
+    const buildItems = meshes
+        .map((_, index) => `        <item objectid="${index + 1}"/>`)
+        .join('\n')
+    const modelXml = `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="millimeter" xml:lang="en-US" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+    <metadata name="Title">${escapeXml(title)}</metadata>
+    <metadata name="Application">Box Grid Generator</metadata>
+    <resources>${resources}
+    </resources>
+    <build>
+${buildItems}
+    </build>
+</model>`
+
+    const zip = new JSZip()
+    zip.file(
+        '[Content_Types].xml',
+        `<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+    <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+    <Default Extension="model" ContentType="application/vnd.ms-package.3dmanufacturing-3dmodel+xml"/>
+</Types>`
+    )
+    zip.folder('_rels')!.file(
+        '.rels',
+        `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Target="/3D/3dmodel.model" Id="rel-1" Type="http://schemas.microsoft.com/3dmanufacturing/2013/01/3dmodel"/>
+</Relationships>`
+    )
+    zip.folder('3D')!.file('3dmodel.model', modelXml)
+
+    return zip.generateAsync({
+        type: 'uint8array',
+        mimeType: 'model/3mf',
+        compression: 'DEFLATE',
+        compressionOptions: { level: 6 },
+    })
+}
+
+function collectMeshes(object: THREE.Object3D): ThreeMfMesh[] {
+    const meshes: ThreeMfMesh[] = []
+    object.traverse((child) => {
+        if (!(child instanceof THREE.Mesh)) return
+        const position = child.geometry.getAttribute('position')
+        const index = child.geometry.getIndex()
+        const vertices = Array.from(
+            { length: position.count },
+            (_, vertexIndex) =>
+                new THREE.Vector3()
+                    .fromBufferAttribute(position, vertexIndex)
+                    .applyMatrix4(child.matrixWorld)
+        )
+        const triangleIndices = index
+            ? Array.from({ length: index.count }, (_, item) => index.getX(item))
+            : Array.from({ length: position.count }, (_, item) => item)
+        const triangles: [number, number, number][] = []
+        for (let item = 0; item < triangleIndices.length; item += 3) {
+            triangles.push([
+                triangleIndices[item],
+                triangleIndices[item + 1],
+                triangleIndices[item + 2],
+            ])
+        }
+        meshes.push({ vertices, triangles })
+    })
+    return meshes
+}
+
+function number(value: number): string {
+    return Number(value.toFixed(6)).toString()
+}
+
+function escapeXml(value: string): string {
+    return value
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&apos;')
+}

--- a/tests/exportUtils.test.ts
+++ b/tests/exportUtils.test.ts
@@ -5,10 +5,13 @@ import {
 } from '@/lib/exportUtils'
 import {
     buildPrintableParts,
+    exportLimits,
+    ExportModelError,
     groupPrintableParts,
     type PrintableModel,
 } from '@/lib/printableModel'
 import JSZip from 'jszip'
+import * as THREE from 'three'
 import { STLLoader } from 'three/examples/jsm/loaders/STLLoader.js'
 import { describe, expect, it } from 'vitest'
 
@@ -79,6 +82,58 @@ function expectBinaryStlToBeWatertight(buffer: ArrayBuffer): void {
     expect(signedVolume).toBeGreaterThan(0)
 }
 
+function expectThreeMfMeshesToBeWatertight(modelXml: string): void {
+    const objects = [
+        ...modelXml.matchAll(
+            /<object id="\d+" type="model">([\s\S]*?)<\/object>/g
+        ),
+    ]
+    expect(objects.length).toBeGreaterThan(0)
+
+    objects.forEach(([, body]) => {
+        const vertices = [
+            ...body.matchAll(/<vertex x="([^"]+)" y="([^"]+)" z="([^"]+)"\/>/g),
+        ].map(
+            ([, x, y, z]) => new THREE.Vector3(Number(x), Number(y), Number(z))
+        )
+        const triangles = [
+            ...body.matchAll(/<triangle v1="(\d+)" v2="(\d+)" v3="(\d+)"\/>/g),
+        ].map(([, a, b, c]) => [Number(a), Number(b), Number(c)])
+        const edges = new Map<string, { count: number; balance: number }>()
+        let signedVolume = 0
+
+        triangles.forEach(([a, b, c]) => {
+            const points = [vertices[a], vertices[b], vertices[c]]
+            expect(
+                points.every((point) => point.toArray().every(Number.isFinite))
+            ).toBe(true)
+            expect(
+                new THREE.Triangle(points[0], points[1], points[2]).getArea()
+            ).toBeGreaterThan(1e-7)
+            signedVolume +=
+                points[0].dot(points[1].clone().cross(points[2])) / 6
+            ;[
+                [a, b],
+                [b, c],
+                [c, a],
+            ].forEach(([from, to]) => {
+                const key = from < to ? `${from}:${to}` : `${to}:${from}`
+                const edge = edges.get(key) ?? { count: 0, balance: 0 }
+                edge.count++
+                edge.balance += from < to ? 1 : -1
+                edges.set(key, edge)
+            })
+        })
+
+        expect(
+            [...edges.values()].every(
+                ({ count, balance }) => count === 2 && balance === 0
+            )
+        ).toBe(true)
+        expect(signedVolume).toBeGreaterThan(0)
+    })
+}
+
 describe('printable model export', () => {
     it('generates deterministic binary STL from domain data', () => {
         const first = generateStl(model())
@@ -109,7 +164,64 @@ describe('printable model export', () => {
         expect(modelXml.match(/<item objectid=/g)).toHaveLength(2)
         expect(modelXml).toContain('<vertices>')
         expect(modelXml).toContain('<triangles>')
+        expectThreeMfMeshesToBeWatertight(modelXml)
     })
+
+    it.each([1, 2, 4])(
+        'exports rounded L-shaped solids at a %d mm radius',
+        async (cornerRadius) => {
+            const orientations = [
+                [
+                    [
+                        { group: 1, width: 20, depth: 20 },
+                        { group: 1, width: 20, depth: 20 },
+                    ],
+                    [
+                        { group: 1, width: 20, depth: 20 },
+                        {
+                            group: 0,
+                            width: 20,
+                            depth: 20,
+                            visibility: 'hidden' as const,
+                        },
+                    ],
+                ],
+                [
+                    [
+                        { group: 1, width: 20, depth: 20 },
+                        {
+                            group: 0,
+                            width: 20,
+                            depth: 20,
+                            visibility: 'hidden' as const,
+                        },
+                    ],
+                    [
+                        { group: 1, width: 20, depth: 20 },
+                        { group: 1, width: 20, depth: 20 },
+                    ],
+                ],
+            ]
+
+            for (const grid of orientations) {
+                const lShape = model({
+                    totalWidth: 40,
+                    totalDepth: 40,
+                    cornerRadius,
+                    grid,
+                })
+                const stl = generateStl(lShape)
+                const threeMf = await generateThreeMf(lShape)
+                const zip = await JSZip.loadAsync(threeMf)
+                const modelXml = await zip
+                    .file('3D/3dmodel.model')!
+                    .async('string')
+
+                expectBinaryStlToBeWatertight(stl)
+                expectThreeMfMeshesToBeWatertight(modelXml)
+            }
+        }
+    )
 
     it('deduplicates identical meshes and keeps different same-size shapes', () => {
         const identical = groupPrintableParts(buildPrintableParts(model()))
@@ -149,6 +261,21 @@ describe('printable model export', () => {
         ])
         expect(groupPrintableParts(shapedParts)).toHaveLength(2)
 
+        const partitionIndependent = buildPrintableParts(
+            model({
+                totalWidth: 60,
+                grid: [
+                    [
+                        { group: 3, width: 10, depth: 20 },
+                        { group: 3, width: 20, depth: 20 },
+                        { group: 0, width: 30, depth: 20 },
+                    ],
+                ],
+            })
+        )
+        expect(groupPrintableParts(partitionIndependent)).toHaveLength(1)
+        expect(groupPrintableParts(partitionIndependent)[0].count).toBe(2)
+
         const rotatedRectangles = buildPrintableParts(
             model({
                 totalWidth: 30,
@@ -177,6 +304,46 @@ describe('printable model export', () => {
         )
         expect(groupPrintableParts(rotatedRectangles)).toHaveLength(1)
         expect(groupPrintableParts(rotatedRectangles)[0].count).toBe(2)
+
+        const lShape = (rotated: boolean) =>
+            buildPrintableParts(
+                model({
+                    totalWidth: 40,
+                    totalDepth: 40,
+                    grid: rotated
+                        ? [
+                              [
+                                  { group: 5, width: 20, depth: 20 },
+                                  {
+                                      group: 0,
+                                      width: 20,
+                                      depth: 20,
+                                      visibility: 'hidden',
+                                  },
+                              ],
+                              [
+                                  { group: 5, width: 20, depth: 20 },
+                                  { group: 5, width: 20, depth: 20 },
+                              ],
+                          ]
+                        : [
+                              [
+                                  { group: 5, width: 20, depth: 20 },
+                                  { group: 5, width: 20, depth: 20 },
+                              ],
+                              [
+                                  { group: 5, width: 20, depth: 20 },
+                                  {
+                                      group: 0,
+                                      width: 20,
+                                      depth: 20,
+                                      visibility: 'hidden',
+                                  },
+                              ],
+                          ],
+                })
+            )[0].shapeSignature
+        expect(lShape(false)).toBe(lShape(true))
     })
 
     it('packs unique binary STL designs with quantity suffixes', async () => {
@@ -191,6 +358,122 @@ describe('printable model export', () => {
         expectBinaryStlToBeWatertight(stl)
         expect(await zip.file('README.txt')!.async('string')).toContain(
             'deduplicated by their generated mesh shape'
+        )
+    })
+
+    it('keeps height, bounds, and filenames consistent for thin models', async () => {
+        for (const wallHeight of [0.1, 2, 2.0001]) {
+            const thinModel = model({ wallHeight, wallThickness: 2 })
+            const stl = generateStl(thinModel)
+            const geometry = new STLLoader().parse(stl)
+            geometry.computeBoundingBox()
+            expect(geometry.boundingBox!.max.z).toBeCloseTo(wallHeight, 4)
+
+            const archive = await generateSeparateStlZip(thinModel)
+            const zip = await JSZip.loadAsync(archive)
+            const stlName = Object.keys(zip.files).find((name) =>
+                name.endsWith('.stl')
+            )!
+            expect(stlName).toContain(`x${wallHeight}mm`)
+            expect(await zip.file('README.txt')!.async('string')).toContain(
+                `Box height: ${wallHeight} mm`
+            )
+
+            const threeMf = await generateThreeMf(thinModel)
+            const threeMfZip = await JSZip.loadAsync(threeMf)
+            const modelXml = await threeMfZip
+                .file('3D/3dmodel.model')!
+                .async('string')
+            const exportedHeights = [
+                ...modelXml.matchAll(
+                    /<vertex x="[^"]+" y="[^"]+" z="([^"]+)"\/>/g
+                ),
+            ].map(([, z]) => Number(z))
+            expect(Math.max(...exportedHeights)).toBeCloseTo(wallHeight, 4)
+            expectBinaryStlToBeWatertight(stl)
+        }
+    })
+
+    it('rejects all-hidden and over-limit exports deterministically', async () => {
+        const hidden = model({
+            grid: [[{ group: 0, width: 20, depth: 20, visibility: 'hidden' }]],
+        })
+        expect(() => generateStl(hidden)).toThrowError(
+            new ExportModelError(
+                'no-visible-parts',
+                'There are no visible boxes to export.'
+            )
+        )
+        await expect(generateThreeMf(hidden)).rejects.toMatchObject({
+            code: 'no-visible-parts',
+        })
+        await expect(generateSeparateStlZip(hidden)).rejects.toMatchObject({
+            code: 'no-visible-parts',
+        })
+
+        const tooManyParts = model({
+            totalWidth: exportLimits.maxVisibleParts + 1,
+            totalDepth: 1,
+            cornerRadius: 0,
+            wallThickness: 0.1,
+            grid: [
+                Array.from(
+                    { length: exportLimits.maxVisibleParts + 1 },
+                    () => ({
+                        group: 0,
+                        width: 1,
+                        depth: 1,
+                    })
+                ),
+            ],
+        })
+        expect(() => generateStl(tooManyParts)).toThrowError(
+            expect.objectContaining({ code: 'part-limit' })
+        )
+
+        const tooManyCells = model({
+            grid: [
+                Array.from({ length: exportLimits.maxCells + 1 }, () => ({
+                    group: 0,
+                    width: 1,
+                    depth: 1,
+                    visibility: 'hidden' as const,
+                })),
+            ],
+        })
+        expect(() => generateStl(tooManyCells)).toThrowError(
+            expect.objectContaining({ code: 'cell-limit' })
+        )
+    })
+
+    it('meets the supported-limit stress latency and memory budgets', async () => {
+        const rows = 10
+        const columns = exportLimits.maxVisibleParts / rows
+        const stressModel = model({
+            totalWidth: columns * 10,
+            totalDepth: rows * 10,
+            cornerRadius: 0,
+            grid: Array.from({ length: rows }, () =>
+                Array.from({ length: columns }, () => ({
+                    group: 0,
+                    width: 10,
+                    depth: 10,
+                }))
+            ),
+        })
+        const heapBefore = process.memoryUsage().heapUsed
+        const startedAt = performance.now()
+        const output = await generateThreeMf(stressModel)
+        const elapsed = performance.now() - startedAt
+        const heapGrowth = Math.max(
+            0,
+            process.memoryUsage().heapUsed - heapBefore
+        )
+
+        expect(elapsed).toBeLessThan(5_000)
+        expect(heapGrowth).toBeLessThan(exportLimits.workerMemoryBudgetBytes)
+        expect(output.byteLength).toBeLessThanOrEqual(
+            exportLimits.maxOutputBytes
         )
     })
 })

--- a/tests/exportUtils.test.ts
+++ b/tests/exportUtils.test.ts
@@ -33,6 +33,21 @@ function model(overrides: Partial<PrintableModel> = {}): PrintableModel {
     }
 }
 
+function gridFromPattern(pattern: string[]): PrintableModel['grid'] {
+    return pattern.map((row) =>
+        [...row].map((cell) =>
+            cell === '#'
+                ? { group: 1, width: 20, depth: 20 }
+                : {
+                      group: 0,
+                      width: 20,
+                      depth: 20,
+                      visibility: 'hidden' as const,
+                  }
+        )
+    )
+}
+
 function expectBinaryStlToBeWatertight(buffer: ArrayBuffer): void {
     const geometry = new STLLoader().parse(buffer)
     const position = geometry.getAttribute('position')
@@ -167,10 +182,10 @@ describe('printable model export', () => {
         expectThreeMfMeshesToBeWatertight(modelXml)
     })
 
-    it.each([1, 2, 4])(
-        'exports rounded L-shaped solids at a %d mm radius',
+    it.each([1, 2, 4, 8])(
+        'exports rounded concave solids at a %d mm radius',
         async (cornerRadius) => {
-            const orientations = [
+            const grids = [
                 [
                     [
                         { group: 1, width: 20, depth: 20 },
@@ -201,17 +216,19 @@ describe('printable model export', () => {
                         { group: 1, width: 20, depth: 20 },
                     ],
                 ],
+                gridFromPattern(['.##.', '##..', '#...', '....']),
+                gridFromPattern(['####', '#...', '....', '....']),
             ]
 
-            for (const grid of orientations) {
-                const lShape = model({
-                    totalWidth: 40,
-                    totalDepth: 40,
+            for (const grid of grids) {
+                const concaveModel = model({
+                    totalWidth: grid[0].length * 20,
+                    totalDepth: grid.length * 20,
                     cornerRadius,
                     grid,
                 })
-                const stl = generateStl(lShape)
-                const threeMf = await generateThreeMf(lShape)
+                const stl = generateStl(concaveModel)
+                const threeMf = await generateThreeMf(concaveModel)
                 const zip = await JSZip.loadAsync(threeMf)
                 const modelXml = await zip
                     .file('3D/3dmodel.model')!

--- a/tests/exportUtils.test.ts
+++ b/tests/exportUtils.test.ts
@@ -1,0 +1,196 @@
+import {
+    generateSeparateStlZip,
+    generateStl,
+    generateThreeMf,
+} from '@/lib/exportUtils'
+import {
+    buildPrintableParts,
+    groupPrintableParts,
+    type PrintableModel,
+} from '@/lib/printableModel'
+import JSZip from 'jszip'
+import { STLLoader } from 'three/examples/jsm/loaders/STLLoader.js'
+import { describe, expect, it } from 'vitest'
+
+function model(overrides: Partial<PrintableModel> = {}): PrintableModel {
+    return {
+        totalWidth: 40,
+        totalDepth: 20,
+        wallThickness: 2,
+        cornerRadius: 4,
+        wallHeight: 30,
+        generateBottom: true,
+        grid: [
+            [
+                { group: 0, width: 20, depth: 20 },
+                { group: 0, width: 20, depth: 20 },
+            ],
+        ],
+        ...overrides,
+    }
+}
+
+function expectBinaryStlToBeWatertight(buffer: ArrayBuffer): void {
+    const geometry = new STLLoader().parse(buffer)
+    const position = geometry.getAttribute('position')
+    const edgeUse = new Map<string, { count: number; balance: number }>()
+    let signedVolume = 0
+    const vertexKey = (index: number) =>
+        [position.getX(index), position.getY(index), position.getZ(index)]
+            .map((value) => (Math.round(value * 1e5) / 1e5).toFixed(5))
+            .join(',')
+
+    for (let index = 0; index < position.count; index += 3) {
+        const [a, b, c] = [index, index + 1, index + 2].map((vertex) => ({
+            x: position.getX(vertex),
+            y: position.getY(vertex),
+            z: position.getZ(vertex),
+        }))
+        signedVolume +=
+            (a.x * (b.y * c.z - b.z * c.y) -
+                a.y * (b.x * c.z - b.z * c.x) +
+                a.z * (b.x * c.y - b.y * c.x)) /
+            6
+        const vertices = [
+            vertexKey(index),
+            vertexKey(index + 1),
+            vertexKey(index + 2),
+        ]
+        ;[
+            [vertices[0], vertices[1]],
+            [vertices[1], vertices[2]],
+            [vertices[2], vertices[0]],
+        ].forEach(([a, b]) => {
+            const key = a < b ? `${a}|${b}` : `${b}|${a}`
+            const edge = edgeUse.get(key) ?? { count: 0, balance: 0 }
+            edge.count++
+            edge.balance += a < b ? 1 : -1
+            edgeUse.set(key, edge)
+        })
+    }
+
+    expect(position.count).toBeGreaterThan(0)
+    expect(new Set([...edgeUse.values()].map(({ count }) => count))).toEqual(
+        new Set([2])
+    )
+    expect(
+        new Set([...edgeUse.values()].map(({ balance }) => balance))
+    ).toEqual(new Set([0]))
+    expect(signedVolume).toBeGreaterThan(0)
+}
+
+describe('printable model export', () => {
+    it('generates deterministic binary STL from domain data', () => {
+        const first = generateStl(model())
+        const second = generateStl(model())
+        const triangleCount = new DataView(first).getUint32(80, true)
+
+        expect([...new Uint8Array(first)]).toEqual([...new Uint8Array(second)])
+        expect(first.byteLength).toBe(84 + triangleCount * 50)
+        expectBinaryStlToBeWatertight(first)
+
+        const geometry = new STLLoader().parse(first)
+        geometry.computeBoundingBox()
+        expect(geometry.boundingBox!.min.toArray()).toEqual([0, 0, 0])
+        expect(geometry.boundingBox!.max.x).toBeCloseTo(45)
+        expect(geometry.boundingBox!.max.y).toBeCloseTo(20)
+        expect(geometry.boundingBox!.max.z).toBeCloseTo(30)
+    })
+
+    it('emits a valid millimeter-based 3MF package', async () => {
+        const data = await generateThreeMf(model())
+        const zip = await JSZip.loadAsync(data)
+        const modelXml = await zip.file('3D/3dmodel.model')!.async('string')
+
+        expect(zip.file('[Content_Types].xml')).not.toBeNull()
+        expect(zip.file('_rels/.rels')).not.toBeNull()
+        expect(modelXml).toContain('<model unit="millimeter" xml:lang="en-US"')
+        expect(modelXml.match(/<object id=/g)).toHaveLength(2)
+        expect(modelXml.match(/<item objectid=/g)).toHaveLength(2)
+        expect(modelXml).toContain('<vertices>')
+        expect(modelXml).toContain('<triangles>')
+    })
+
+    it('deduplicates identical meshes and keeps different same-size shapes', () => {
+        const identical = groupPrintableParts(buildPrintableParts(model()))
+        expect(identical).toHaveLength(1)
+        expect(identical[0].count).toBe(2)
+
+        const sameBoundsDifferentShapes = model({
+            totalWidth: 70,
+            grid: [
+                [
+                    { group: 1, width: 10, depth: 10 },
+                    { group: 1, width: 10, depth: 10 },
+                    { group: 1, width: 10, depth: 10 },
+                    { group: 0, width: 10, depth: 10, visibility: 'hidden' },
+                    { group: 2, width: 10, depth: 10 },
+                    { group: 2, width: 10, depth: 10 },
+                    { group: 2, width: 10, depth: 10 },
+                ],
+                [
+                    { group: 1, width: 10, depth: 10 },
+                    { group: 0, width: 10, depth: 10, visibility: 'hidden' },
+                    { group: 0, width: 10, depth: 10, visibility: 'hidden' },
+                    { group: 0, width: 10, depth: 10, visibility: 'hidden' },
+                    { group: 0, width: 10, depth: 10, visibility: 'hidden' },
+                    { group: 2, width: 10, depth: 10 },
+                    { group: 0, width: 10, depth: 10, visibility: 'hidden' },
+                ],
+            ],
+        })
+        const shapedParts = buildPrintableParts(
+            sameBoundsDifferentShapes
+        ).filter((part) => part.metadata.isCombined)
+
+        expect(shapedParts.map((part) => part.metadata.dimensions)).toEqual([
+            { width: 30, depth: 20, height: 30 },
+            { width: 30, depth: 20, height: 30 },
+        ])
+        expect(groupPrintableParts(shapedParts)).toHaveLength(2)
+
+        const rotatedRectangles = buildPrintableParts(
+            model({
+                totalWidth: 30,
+                totalDepth: 30,
+                grid: [
+                    [
+                        {
+                            group: 0,
+                            width: 10,
+                            depth: 10,
+                            visibility: 'hidden',
+                        },
+                        { group: 0, width: 20, depth: 10 },
+                    ],
+                    [
+                        { group: 0, width: 10, depth: 20 },
+                        {
+                            group: 0,
+                            width: 20,
+                            depth: 20,
+                            visibility: 'hidden',
+                        },
+                    ],
+                ],
+            })
+        )
+        expect(groupPrintableParts(rotatedRectangles)).toHaveLength(1)
+        expect(groupPrintableParts(rotatedRectangles)[0].count).toBe(2)
+    })
+
+    it('packs unique binary STL designs with quantity suffixes', async () => {
+        const data = await generateSeparateStlZip(model())
+        const zip = await JSZip.loadAsync(data)
+        const stlNames = Object.keys(zip.files).filter((name) =>
+            name.endsWith('.stl')
+        )
+        const stl = await zip.file(stlNames[0])!.async('arraybuffer')
+
+        expect(stlNames).toEqual(['box_1_20x20x30mm_qty2.stl'])
+        expectBinaryStlToBeWatertight(stl)
+        expect(await zip.file('README.txt')!.async('string')).toContain(
+            'deduplicated by their generated mesh shape'
+        )
+    })
+})

--- a/tests/exportWorker.test.ts
+++ b/tests/exportWorker.test.ts
@@ -1,0 +1,76 @@
+import { runExport } from '@/lib/exportClient'
+import type { ExportWorkerResponse } from '@/lib/exportProtocol'
+import { processExportRequest } from '@/lib/exportWorker'
+import type { PrintableModel } from '@/lib/printableModel'
+import { describe, expect, it } from 'vitest'
+
+function model(visible = true): PrintableModel {
+    return {
+        totalWidth: 20,
+        totalDepth: 20,
+        wallThickness: 2,
+        cornerRadius: 4,
+        wallHeight: 30,
+        generateBottom: true,
+        grid: [
+            [
+                {
+                    group: 0,
+                    width: 20,
+                    depth: 20,
+                    visibility: visible ? 'visible' : 'hidden',
+                },
+            ],
+        ],
+    }
+}
+
+describe('export worker protocol', () => {
+    it('reports progress and returns transferable export data', async () => {
+        const responses: ExportWorkerResponse[] = []
+
+        await processExportRequest(
+            { format: 'stl', model: model() },
+            (message) => responses.push(message)
+        )
+
+        expect(
+            responses.filter((response) => response.type === 'progress')
+        ).toHaveLength(3)
+        const result = responses.find((response) => response.type === 'result')
+        expect(result).toMatchObject({ type: 'result' })
+        expect(
+            result?.type === 'result' && result.data.byteLength
+        ).toBeGreaterThan(84)
+    })
+
+    it('serializes model validation failures instead of rejecting', async () => {
+        const responses: ExportWorkerResponse[] = []
+
+        await processExportRequest(
+            { format: '3mf', model: model(false) },
+            (message) => responses.push(message)
+        )
+
+        expect(responses.at(-1)).toEqual({
+            type: 'error',
+            name: 'ExportModelError',
+            code: 'no-visible-parts',
+            message: 'There are no visible boxes to export.',
+        })
+    })
+
+    it('honors cancellation before loading a worker', async () => {
+        const controller = new AbortController()
+        controller.abort()
+
+        await expect(
+            runExport({
+                format: 'stl',
+                model: model(),
+                signal: controller.signal,
+                onProgress: () => undefined,
+            })
+        ).rejects.toMatchObject({ name: 'AbortError' })
+    })
+})

--- a/tests/geometry.test.ts
+++ b/tests/geometry.test.ts
@@ -160,7 +160,10 @@ function hasFootprintPoint(
     })
 }
 
-function projectedTriangleArea(mesh: THREE.Mesh): number {
+function horizontalTriangleAreaAtHeight(
+    mesh: THREE.Mesh,
+    height: number
+): number {
     mesh.updateMatrixWorld(true)
 
     const position = mesh.geometry.getAttribute('position')
@@ -195,15 +198,71 @@ function projectedTriangleArea(mesh: THREE.Mesh): number {
             triangle[corner].copy(vertex)
         }
 
-        area +=
-            Math.abs(
-                triangle[0].x * (triangle[1].z - triangle[2].z) +
-                    triangle[1].x * (triangle[2].z - triangle[0].z) +
-                    triangle[2].x * (triangle[0].z - triangle[1].z)
-            ) / 2
+        if (triangle.every((point) => Math.abs(point.y - height) < 1e-5)) {
+            area +=
+                Math.abs(
+                    triangle[0].x * (triangle[1].z - triangle[2].z) +
+                        triangle[1].x * (triangle[2].z - triangle[0].z) +
+                        triangle[2].x * (triangle[0].z - triangle[1].z)
+                ) / 2
+        }
     }
 
     return area
+}
+
+function hasVertexAtHeight(object: THREE.Object3D, height: number): boolean {
+    return meshes(object).some((mesh) => {
+        const position = mesh.geometry.getAttribute('position')
+        return Array.from({ length: position.count }, (_, index) =>
+            position.getY(index)
+        ).some((value) => Math.abs(value - height) < 1e-5)
+    })
+}
+
+function expectWatertight(object: THREE.Object3D): void {
+    meshes(object).forEach((mesh) => {
+        const position = mesh.geometry.getAttribute('position')
+        const index = mesh.geometry.getIndex()
+        expect(index).not.toBeNull()
+
+        const edgeUse = new Map<string, { count: number; balance: number }>()
+        const triangleCount = index!.count / 3
+        for (
+            let triangleIndex = 0;
+            triangleIndex < triangleCount;
+            triangleIndex++
+        ) {
+            const vertices = [0, 1, 2].map((corner) =>
+                index!.getX(triangleIndex * 3 + corner)
+            )
+            const points = vertices.map((vertexIndex) =>
+                new THREE.Vector3().fromBufferAttribute(position, vertexIndex)
+            )
+            expect(
+                new THREE.Triangle(points[0], points[1], points[2]).getArea()
+            ).toBeGreaterThan(1e-8)
+
+            ;[
+                [vertices[0], vertices[1]],
+                [vertices[1], vertices[2]],
+                [vertices[2], vertices[0]],
+            ].forEach(([a, b]) => {
+                const key = a < b ? `${a}:${b}` : `${b}:${a}`
+                const edge = edgeUse.get(key) ?? { count: 0, balance: 0 }
+                edge.count++
+                edge.balance += a < b ? 1 : -1
+                edgeUse.set(key, edge)
+            })
+        }
+
+        expect(
+            new Set([...edgeUse.values()].map(({ count }) => count))
+        ).toEqual(new Set([2]))
+        expect(
+            new Set([...edgeUse.values()].map(({ balance }) => balance))
+        ).toEqual(new Set([0]))
+    })
 }
 
 describe('geometry outlines', () => {
@@ -361,7 +420,7 @@ describe('box generation', () => {
         const size = boundingSize(cell)
 
         expect(box.children).toHaveLength(1)
-        expect(meshes(cell)).toHaveLength(2)
+        expect(meshes(cell)).toHaveLength(1)
         expect(cell.visible).toBe(true)
         expect(getGridBoxes(grid, 30)[0].dimensions).toMatchObject({
             width: 30,
@@ -371,22 +430,24 @@ describe('box generation', () => {
         expect(size.y).toBeCloseTo(30)
         expect(size.z).toBeCloseTo(20)
         expectFiniteGeometry(cell)
+        expectWatertight(cell)
     })
 
     it('omits bottom geometry when bottom generation is disabled', () => {
         const grid: Grid = [[{ group: 0, width: 30, depth: 20 }]]
 
-        expect(
-            meshes(
-                generateCustomBox(
-                    grid,
-                    generationOptions({ generateBottom: false })
-                )
-            )
-        ).toHaveLength(1)
-        expect(
-            meshes(generateCustomBox(grid, generationOptions()))
-        ).toHaveLength(2)
+        const bottomless = generateCustomBox(
+            grid,
+            generationOptions({ generateBottom: false })
+        )
+        const bottomed = generateCustomBox(grid, generationOptions())
+
+        expect(meshes(bottomless)).toHaveLength(1)
+        expect(meshes(bottomed)).toHaveLength(1)
+        expect(hasVertexAtHeight(bottomless, 2)).toBe(false)
+        expect(hasVertexAtHeight(bottomed, 2)).toBe(true)
+        expectWatertight(bottomless)
+        expectWatertight(bottomed)
     })
 
     it('generates one box for combined cells and split boxes after ungrouping', () => {
@@ -447,7 +508,7 @@ describe('box generation', () => {
         )
 
         expect(combined).toBeDefined()
-        expect(meshes(combined!)).toHaveLength(2)
+        expect(meshes(combined!)).toHaveLength(1)
         expect(metadata?.cells).toEqual([
             { x: 0, z: 0 },
             { x: 1, z: 0 },
@@ -464,9 +525,10 @@ describe('box generation', () => {
         expect(size.z).toBeCloseTo(70)
         expectFiniteGeometry(combined!)
 
-        const combinedMeshes = meshes(combined!)
-        const bottomMesh = combinedMeshes[1]
-        expect(projectedTriangleArea(bottomMesh) / 2).toBeCloseTo(1300)
+        expect(
+            horizontalTriangleAreaAtHeight(meshes(combined!)[0], 0)
+        ).toBeCloseTo(1300)
+        expectWatertight(combined!)
 
         const footprint = footprintPoints(combined!)
         expect(hasFootprintPoint(footprint, (x, z) => x >= 28 && z <= 30)).toBe(
@@ -527,8 +589,8 @@ describe('box generation', () => {
             .material as THREE.LineBasicMaterial
 
         expect(size.y).toBeCloseTo(18)
-        expect(boxMeshes).toHaveLength(2)
-        expect(boundingSize(boxMeshes[1]).y).toBeCloseTo(2)
+        expect(boxMeshes).toHaveLength(1)
+        expect(hasVertexAtHeight(box, 2)).toBe(true)
         expect(roundedPositionCount).toBeGreaterThan(sharpPositionCount)
         expect(lines).toHaveLength(2)
         expect(lineMaterial.color.getHex()).toBe(0x123456)

--- a/tests/geometry.test.ts
+++ b/tests/geometry.test.ts
@@ -71,6 +71,30 @@ function generationOptions(
     }
 }
 
+function polyominoGrid(mask: number, size = 4): Grid {
+    return Array.from({ length: size }, (_, z) =>
+        Array.from({ length: size }, (_, x) => {
+            const selected = (mask & (1 << (z * size + x))) !== 0
+            return {
+                group: selected ? 1 : 0,
+                width: 20,
+                depth: 20,
+                visibility: selected
+                    ? ('visible' as const)
+                    : ('hidden' as const),
+            }
+        })
+    )
+}
+
+function selectionForMask(mask: number, size = 4) {
+    return Array.from({ length: size * size }, (_, index) => index)
+        .filter((index) => (mask & (1 << index)) !== 0)
+        .map((index) => ({
+            cells: [{ x: index % size, z: Math.floor(index / size) }],
+        }))
+}
+
 function expectFiniteGeometry(object: THREE.Object3D): void {
     const objectMeshes = meshes(object)
     expect(objectMeshes.length).toBeGreaterThan(0)
@@ -596,6 +620,67 @@ describe('box generation', () => {
         expect(lineMaterial.color.getHex()).toBe(0x123456)
         expect(lineMaterial.opacity).toBe(0.4)
     })
+
+    it('keeps thin-model helper lines within the clamped model height', () => {
+        const grid: Grid = [[{ group: 0, width: 20, depth: 20 }]]
+        const options = generationOptions({
+            wallThickness: 2,
+            wallHeight: 0.1,
+            generateBottom: true,
+            cornerLines: { show: true, color: 0, opacity: 1 },
+        })
+
+        const withoutHelpers = generateCustomBox(grid, {
+            ...options,
+            cornerLines: { ...options.cornerLines, show: false },
+        })
+        const withHelpers = generateCustomBox(grid, options)
+
+        expect(boundingSize(withoutHelpers).y).toBeCloseTo(0.1)
+        expect(boundingSize(withHelpers).y).toBeCloseTo(0.1)
+    })
+
+    it('generates a watertight rounded mesh corpus for accepted polyominoes', () => {
+        const explicitMasks = [
+            // .##. / ##.. / #... / ....
+            (1 << 1) | (1 << 2) | (1 << 4) | (1 << 5) | (1 << 8),
+            // #### / #... / .... / ....
+            (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) | (1 << 4),
+        ]
+        const corpusSize = 1_000
+        const acceptedMasks: number[] = []
+        for (
+            let mask = 1;
+            mask < 1 << 16 && acceptedMasks.length < corpusSize;
+            mask++
+        ) {
+            const selection = selectionForMask(mask)
+            if (selection.length < 2) continue
+            const candidate = polyominoGrid(0).map((row) =>
+                row.map((cell) => ({ ...cell, visibility: 'visible' as const }))
+            )
+            if (validateGridBoxCombination(candidate, selection).valid) {
+                acceptedMasks.push(mask)
+            }
+        }
+        const corpus = [...new Set([...explicitMasks, ...acceptedMasks])]
+
+        for (const radius of [1, 2, 4, 8]) {
+            for (const mask of corpus) {
+                const generated = generateCustomBox(
+                    polyominoGrid(mask),
+                    generationOptions({
+                        cornerRadius: radius,
+                        includeHidden: false,
+                    })
+                )
+                expect(generated.children).toHaveLength(1)
+                expectWatertight(generated)
+            }
+        }
+
+        expect(acceptedMasks).toHaveLength(corpusSize)
+    }, 30_000)
 
     const explicitOptions = generationOptions({
         wallThickness: 2,


### PR DESCRIPTION
## Summary

- replace overlapping wall and bottom meshes with one indexed, watertight solid for both bottomed and bottomless boxes
- triangulate rounded concave rims by corresponding corners and horizontal faces with a deterministic, non-degenerate ear clipper
- generate STL/3MF export meshes from an immutable domain-model snapshot, independent of the live Three.js scene, helpers, camera, selection, and display state
- export deterministic binary STL print plates with spacing, standards-based millimeter 3MF packages, and binary per-design STL ZIP archives
- deduplicate separate designs by their canonical union boundary and mesh-affecting settings, retaining rotational equivalence without depending on source-cell partitioning
- run bounded exports in a cancellable worker with visible progress, deterministic errors, and lazy-loaded format/compression code

## Why

The previous bottom slab overlapped the wall shell, adjacent boxes introduced coincident faces in the single STL, rounded concave outlines could emit degenerate triangles, and separate STL deduplication used only bounding dimensions. Export generation also ran synchronously on the browser main thread. These changes make every printable part a validated, consistently wound closed manifold and make exports deterministic and responsive from the saved model configuration.

## User impact

- STL export is now a spaced print-plate layout so individual boxes remain separate printable shells
- 3MF export is available directly and preserves each box as its own object with millimeter units
- valid rounded concave combinations export reliably at radii below, equal to, and above wall thickness
- separate STL archives correctly count physically identical or rotated designs without conflating different same-size shapes
- bottom thickness is capped by model height and shared by mesh/helper geometry, so helper lines cannot enlarge thin-model bounds
- all-hidden, oversized, failed, and cancelled exports surface deterministic UI states instead of uncaught errors
- exports support 2,500 cells, 250 visible parts, and 32 MB output; hidden parts are filtered before geometry generation

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test` (83 tests)
- first 1,000 accepted 4×4 polyominoes generate watertight meshes at 1, 2, 4, and 8 mm radii
- both reported concave footprints export as watertight binary STL and 3MF at 1, 2, 4, and 8 mm radii
- thin 0.1 mm model bounds remain 0.1 mm with corner helpers enabled
- supported-limit 3MF stress benchmark: under 5 seconds, under 128 MB heap growth, and under 32 MB output
- `npm run build`
- production page-manifest inspection: no JSZip, STL exporter, or 3MF payload in initial route chunks; export worker payload is on demand (201,155 bytes raw / 58,867 gzip)

Linear: TW-209, TW-210, TW-211
