### PR TITLE
Refactor STL export to build from model snapshots

### DIFF
--- a/lib/exportModel.ts
+++ b/lib/exportModel.ts
@@ -1,0 +1,97 @@
+import { generateCustomBox } from '@/lib/boxHelper'
+import { getGridBoxes } from '@/lib/gridVisibility'
+import { disposeObject } from '@/lib/threeDisposal'
+import type {
+    DrawerInsert,
+    GeneratedBoxMetadata,
+    Grid,
+    ModelConfig,
+} from '@/lib/types'
+import * as THREE from 'three'
+
+export type ExportBoxMesh = {
+    metadata: GeneratedBoxMetadata
+    mesh: THREE.Group
+}
+
+/**
+ * Builds the complete printable assembly directly from a domain-model snapshot.
+ * Display-only geometry and hidden boxes are never added to the result.
+ */
+export function buildExportAssembly(model: DrawerInsert): THREE.Group {
+    const generated = generateCustomBox(model.grid, exportOptions(model.config))
+    const visibleIds = new Set(
+        getGridBoxes(model.grid, model.config.wallHeight)
+            .filter((box) => box.visibility === 'visible')
+            .map((box) => box.id)
+    )
+
+    for (const child of [...generated.children]) {
+        if (visibleIds.has(child.name as GeneratedBoxMetadata['id'])) {
+            child.visible = true
+            continue
+        }
+
+        generated.remove(child)
+        disposeObject(child)
+    }
+
+    return generated
+}
+
+/**
+ * Builds one locally positioned mesh per visible domain box. The returned order
+ * comes from the grid model, rather than the order of objects in a render scene.
+ */
+export function buildExportBoxMeshes(model: DrawerInsert): ExportBoxMesh[] {
+    const assembly = buildExportAssembly(model)
+    const meshesById = new Map(
+        assembly.children.map((child) => [child.name, child as THREE.Group])
+    )
+    const result = getGridBoxes(model.grid, model.config.wallHeight)
+        .filter((metadata) => metadata.visibility === 'visible')
+        .map((metadata) => {
+            const mesh = meshesById.get(metadata.id)
+            if (!mesh) {
+                throw new Error(`Missing generated mesh for ${metadata.id}.`)
+            }
+
+            assembly.remove(mesh)
+            positionAtLocalOrigin(mesh, model.grid, metadata)
+            return { metadata, mesh }
+        })
+
+    disposeObject(assembly)
+    return result
+}
+
+function exportOptions(config: ModelConfig) {
+    return {
+        wallThickness: config.wallThickness,
+        cornerRadius: config.cornerRadius,
+        wallHeight: config.wallHeight,
+        generateBottom: config.generateBottom,
+        cornerLines: {
+            show: false,
+            color: 0,
+            opacity: 0,
+        },
+    }
+}
+
+function positionAtLocalOrigin(
+    mesh: THREE.Group,
+    grid: Grid,
+    metadata: GeneratedBoxMetadata
+): void {
+    const firstColumn = Math.min(...metadata.cells.map(({ x }) => x))
+    const firstRow = Math.min(...metadata.cells.map(({ z }) => z))
+    const xOffset = grid[0]
+        .slice(0, firstColumn)
+        .reduce((sum, cell) => sum + cell.width, 0)
+    const zOffset = grid
+        .slice(0, firstRow)
+        .reduce((sum, row) => sum + row[0].depth, 0)
+
+    mesh.position.set(-xOffset, 0, -zOffset)
+}

--- a/lib/exportUtils.ts
+++ b/lib/exportUtils.ts
@@ -1,53 +1,30 @@
-import { generateCustomBox } from '@/lib/boxHelper'
-import { getGridBoxes } from '@/lib/gridVisibility'
+import {
+    buildExportAssembly,
+    buildExportBoxMeshes,
+    type ExportBoxMesh,
+} from '@/lib/exportModel'
 import { useStore } from '@/lib/store'
 import { disposeObject } from '@/lib/threeDisposal'
+import type { DrawerInsert, StoreState } from '@/lib/types'
 import * as THREE from 'three'
 import { STLExporter } from 'three/examples/jsm/exporters/STLExporter.js'
 
 /**
- * Export the entire scene as one single STL
+ * Export the domain model as one single STL.
  */
 export function handleStlExport(): void {
-    const state = useStore.getState()
-    const grid = state.grid
-    if (grid.length === 0) return
+    const model = createExportModelSnapshot(useStore.getState())
+    if (model.grid.length === 0) return
 
-    // Wrap & rotate so Three's Y-up becomes STL Z-up
-    const tmpScene = new THREE.Scene()
-    const box = generateCustomBox(grid, {
-        wallThickness: state.wallThickness,
-        cornerRadius: state.cornerRadius,
-        wallHeight: state.wallHeight,
-        generateBottom: state.generateBottom,
-        cornerLines: {
-            show: false,
-            color: state.cornerLineColor,
-            opacity: state.cornerLineOpacity,
-        },
-    })
-    removeHiddenObjects(box)
-    box.position.set(0, 0, 0)
-    box.rotation.set(Math.PI / 2, 0, 0)
-    tmpScene.add(box)
-    tmpScene.updateMatrixWorld()
-
-    const exporter = new STLExporter()
-    let stlString: string
+    const assembly = buildExportAssembly(model)
     try {
-        stlString = exporter.parse(tmpScene, { binary: false })
-    } catch {
-        stlString = exporter.parse(tmpScene)
+        downloadBlob(
+            new Blob([serializeStl(assembly)], { type: 'text/plain' }),
+            `drawer-inserts-${model.config.totalWidth}x${model.config.totalDepth}x${model.config.wallHeight}-single-box.stl`
+        )
+    } finally {
+        disposeObject(assembly)
     }
-
-    const blob = new Blob([stlString], { type: 'text/plain' })
-    const link = document.createElement('a')
-    link.href = URL.createObjectURL(blob)
-    link.download = `drawer-inserts-${state.totalWidth}x${state.totalDepth}x${state.wallHeight}-single-box.stl`
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
-    setTimeout(() => URL.revokeObjectURL(link.href), 100)
 }
 
 /**
@@ -55,29 +32,14 @@ export function handleStlExport(): void {
  * with a `_qtyN` suffix and pack into a ZIP.
  */
 export async function handleExportMultipleSTLs(): Promise<void> {
-    const state = useStore.getState()
-    const grid = state.grid
-    if (grid.length === 0) return
+    const model = createExportModelSnapshot(useStore.getState())
+    if (model.grid.length === 0) return
 
-    const boxGroup = generateCustomBox(grid, {
-        wallThickness: state.wallThickness,
-        cornerRadius: state.cornerRadius,
-        wallHeight: state.wallHeight,
-        generateBottom: state.generateBottom,
-        cornerLines: {
-            show: false,
-            color: state.cornerLineColor,
-            opacity: state.cornerLineOpacity,
-        },
-    })
-
-    const boxWidths = grid[0].map((cell) => cell.width)
-    const boxDepths = grid.map((row) => row[0].depth)
-    const gridBoxes = getGridBoxes(grid, state.wallHeight)
+    const exportMeshes = buildExportBoxMeshes(model)
 
     // group boxes by dimensions (ignoring width↔depth swap)
     type GroupInfo = {
-        representative: THREE.Object3D
+        representative: ExportBoxMesh
         count: number
         w: number
         d: number
@@ -86,10 +48,8 @@ export async function handleExportMultipleSTLs(): Promise<void> {
     }
     const groups = new Map<string, GroupInfo>()
 
-    boxGroup.children.forEach((box) => {
-        const metadata = gridBoxes.find((entry) => entry.id === box.name)
-        if (!metadata || metadata.visibility === 'hidden') return
-
+    exportMeshes.forEach((entry) => {
+        const metadata = entry.metadata
         const rawW = metadata.dimensions.width
         const rawD = metadata.dimensions.depth
         const h = metadata.dimensions.height
@@ -102,7 +62,7 @@ export async function handleExportMultipleSTLs(): Promise<void> {
             groups.get(key)!.count++
         } else {
             groups.set(key, {
-                representative: box,
+                representative: entry,
                 count: 1,
                 w,
                 d,
@@ -112,77 +72,92 @@ export async function handleExportMultipleSTLs(): Promise<void> {
         }
     })
 
-    const JSZip = (await import('jszip')).default
-    const zip = new JSZip()
-    const exporter = new STLExporter()
-    let uniqIndex = 1
+    try {
+        const JSZip = (await import('jszip')).default
+        const zip = new JSZip()
+        let uniqIndex = 1
 
-    for (const [, info] of groups) {
-        const { representative, count, w, d, h, isCombined } = info
-
-        // Wrap & rotate so Three's Y-up becomes STL Z-up
-        const tmpScene = new THREE.Scene()
-        const sceneClone = representative.clone(true)
-        sceneClone.position.set(0, 0, 0)
-        sceneClone.rotation.set(Math.PI / 2, 0, 0)
-        tmpScene.add(sceneClone)
-        tmpScene.updateMatrixWorld()
-
-        let stlString: string
-        try {
-            stlString = exporter.parse(tmpScene, { binary: false })
-        } catch {
-            stlString = exporter.parse(tmpScene)
+        for (const [, info] of groups) {
+            const { representative, count, w, d, h, isCombined } = info
+            const qtySuffix = count > 1 ? `_qty${count}` : ''
+            const filename = `${isCombined ? 'combined_box' : 'box'}_${uniqIndex}_${w.toFixed(0)}x${d.toFixed(0)}x${h.toFixed(0)}mm${qtySuffix}.stl`
+            zip.file(filename, serializeStl(representative.mesh))
+            uniqIndex++
         }
 
-        const qtySuffix = count > 1 ? `_qty${count}` : ''
-        const filename = `${isCombined ? 'combined_box' : 'box'}_${uniqIndex}_${w.toFixed(0)}x${d.toFixed(0)}x${h.toFixed(0)}mm${qtySuffix}.stl`
-        zip.file(filename, stlString)
-        uniqIndex++
-    }
+        const readme = `# Box Grid Export
 
-    // README
-    const uniqueCount = groups.size
-    const cols = boxWidths.length
-    const rows = boxDepths.length
-    const readme = `# Box Grid Export
-
-This ZIP contains ${uniqueCount} unique box designs (_qtyN suffix shows multiples_).
+This ZIP contains ${groups.size} unique box designs (_qtyN suffix shows multiples_).
 
 ## File Naming Convention
 - Regular boxes: box_[i]_[W]x[D]x[H]mm[_qtyN].stl  
 - Combined boxes: combined_box_[i]_[W]x[D]x[H]mm[_qtyN].stl  
 
 ## Grid Layout
-- Grid size: ${cols}×${rows}  
-- Total width: ${state.totalWidth} mm  
-- Total depth: ${state.totalDepth} mm  
-- Box height: ${state.wallHeight} mm  
-- Wall thickness: ${state.wallThickness} mm  
+- Grid size: ${model.grid[0].length}×${model.grid.length}
+- Total width: ${model.config.totalWidth} mm
+- Total depth: ${model.config.totalDepth} mm
+- Box height: ${model.config.wallHeight} mm
+- Wall thickness: ${model.config.wallThickness} mm
 
 Thanks for using Box Grid Generator by timoweiss.me!
 Happy printing!
 `
-    zip.file('README.txt', readme)
+        zip.file('README.txt', readme)
 
-    const content = await zip.generateAsync({ type: 'blob' })
+        const content = await zip.generateAsync({ type: 'blob' })
+        downloadBlob(
+            content,
+            `drawer-inserts-${model.config.totalWidth}x${model.config.totalDepth}x${model.config.wallHeight}-grid.zip`
+        )
+    } finally {
+        exportMeshes.forEach(({ mesh }) => disposeObject(mesh))
+    }
+}
+
+/** Capture only domain state so later UI/store changes cannot affect an export. */
+export function createExportModelSnapshot(state: StoreState): DrawerInsert {
+    return {
+        config: {
+            totalWidth: state.totalWidth,
+            totalDepth: state.totalDepth,
+            wallThickness: state.wallThickness,
+            cornerRadius: state.cornerRadius,
+            wallHeight: state.wallHeight,
+            generateBottom: state.generateBottom,
+            maxBoxWidth: state.maxBoxWidth,
+            maxBoxDepth: state.maxBoxDepth,
+        },
+        grid: state.grid.map((row) => row.map((cell) => ({ ...cell }))),
+        selectedBoxIds: [...state.selectedBoxIds],
+    }
+}
+
+/** Serialize a generated mesh using the fixed Y-up to STL Z-up transform. */
+export function serializeStl(object: THREE.Object3D): string {
+    const exportRoot = new THREE.Group()
+    exportRoot.rotation.set(Math.PI / 2, 0, 0)
+    exportRoot.add(object)
+    exportRoot.updateMatrixWorld(true)
+
+    const exporter = new STLExporter()
+    try {
+        try {
+            return exporter.parse(exportRoot, { binary: false }) as string
+        } catch {
+            return exporter.parse(exportRoot) as string
+        }
+    } finally {
+        exportRoot.remove(object)
+    }
+}
+
+function downloadBlob(blob: Blob, filename: string): void {
     const link = document.createElement('a')
-    link.href = URL.createObjectURL(content)
-    link.download = `drawer-inserts-${state.totalWidth}x${state.totalDepth}x${state.wallHeight}-grid.zip`
+    link.href = URL.createObjectURL(blob)
+    link.download = filename
     document.body.appendChild(link)
     link.click()
     document.body.removeChild(link)
     setTimeout(() => URL.revokeObjectURL(link.href), 100)
-    disposeObject(boxGroup)
-}
-
-function removeHiddenObjects(object: THREE.Object3D): void {
-    for (const child of [...object.children]) {
-        if (!child.visible) {
-            object.remove(child)
-            continue
-        }
-
-        removeHiddenObjects(child)
-    }
 }

--- a/tests/exportModel.test.ts
+++ b/tests/exportModel.test.ts
@@ -1,0 +1,170 @@
+import { buildExportAssembly, buildExportBoxMeshes } from '@/lib/exportModel'
+import { createExportModelSnapshot, serializeStl } from '@/lib/exportUtils'
+import { useStore } from '@/lib/store'
+import { disposeObject } from '@/lib/threeDisposal'
+import type { DrawerInsert, Grid } from '@/lib/types'
+import * as THREE from 'three'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const objectsToDispose: THREE.Object3D[] = []
+
+afterEach(() => {
+    objectsToDispose.splice(0).forEach(disposeObject)
+})
+
+describe('export model generation', () => {
+    it('builds only printable domain geometry with no display helpers', () => {
+        const assembly = track(buildExportAssembly(createModel()))
+        const names = assembly.children.map((child) => child.name)
+        const size = new THREE.Box3()
+            .setFromObject(assembly)
+            .getSize(new THREE.Vector3())
+
+        expect(names).toEqual(['group:7', 'cell:0:1'])
+        expect(size.y).toBeCloseTo(24)
+        expect(
+            assembly.getObjectsByProperty('name', 'corner-lines')
+        ).toHaveLength(0)
+        expect(assembly.children.every((child) => child.visible)).toBe(true)
+    })
+
+    it('positions separate meshes at a stable local origin in model order', () => {
+        const entries = buildExportBoxMeshes(createModel())
+        entries.forEach(({ mesh }) => track(mesh))
+
+        expect(entries.map(({ metadata }) => metadata.id)).toEqual([
+            'group:7',
+            'cell:0:1',
+        ])
+        entries.forEach(({ mesh }) => {
+            const bounds = new THREE.Box3().setFromObject(mesh)
+            expect(bounds.min.x).toBeCloseTo(0)
+            expect(bounds.min.y).toBeCloseTo(0)
+            expect(bounds.min.z).toBeCloseTo(0)
+        })
+    })
+
+    it('serializes deterministically despite display-state changes', () => {
+        const grid = createGrid()
+        useStore.setState({
+            ...createModel(grid).config,
+            grid,
+            selectedBoxIds: ['group:7'],
+            showHelperGrid: true,
+            showCornerLines: true,
+            cornerLineColor: 0xff0000,
+            cornerLineOpacity: 1,
+            standardColor: 0x123456,
+            selectedColor: 0x654321,
+        })
+        const firstSnapshot = createExportModelSnapshot(useStore.getState())
+        const firstAssembly = track(buildExportAssembly(firstSnapshot))
+        const firstStl = serializeStl(firstAssembly)
+
+        useStore.setState({
+            showHelperGrid: false,
+            showCornerLines: false,
+            cornerLineColor: 0x00ff00,
+            cornerLineOpacity: 0.1,
+            standardColor: 0xffffff,
+            selectedColor: 0x000000,
+            selectedBoxIds: [],
+        })
+        const secondAssembly = track(
+            buildExportAssembly(createExportModelSnapshot(useStore.getState()))
+        )
+
+        expect(serializeStl(secondAssembly)).toBe(firstStl)
+    })
+
+    it('does not inherit transforms or helpers from an existing scene', () => {
+        const model = createModel()
+        const expectedAssembly = track(buildExportAssembly(model))
+        const expectedStl = serializeStl(expectedAssembly)
+        const displayedAssembly = buildExportAssembly(model)
+        const liveScene = track(new THREE.Scene())
+
+        displayedAssembly.position.set(100, 200, 300)
+        displayedAssembly.rotation.set(0.2, 0.4, 0.6)
+        displayedAssembly.scale.setScalar(2)
+        displayedAssembly.children[0].visible = false
+        liveScene.add(
+            new THREE.PerspectiveCamera(),
+            new THREE.GridHelper(500, 50),
+            displayedAssembly
+        )
+
+        const exportedAssembly = track(buildExportAssembly(model))
+
+        expect(serializeStl(exportedAssembly)).toBe(expectedStl)
+    })
+
+    it('captures grid data instead of retaining mutable store cells', () => {
+        const grid = createGrid()
+        useStore.setState({ ...createModel(grid).config, grid })
+        const snapshot = createExportModelSnapshot(useStore.getState())
+
+        grid[1][1].width = 999
+        grid[1][1].visibility = 'hidden'
+
+        expect(snapshot.grid[1][1]).toMatchObject({
+            width: 40,
+            visibility: 'visible',
+        })
+    })
+})
+
+function createGrid(): Grid {
+    return [
+        [
+            {
+                group: 0,
+                width: 20,
+                depth: 30,
+                visibility: 'hidden',
+            },
+            {
+                group: 0,
+                width: 40,
+                depth: 30,
+                visibility: 'hidden',
+            },
+        ],
+        [
+            {
+                group: 0,
+                width: 20,
+                depth: 50,
+                visibility: 'visible',
+            },
+            {
+                group: 7,
+                width: 40,
+                depth: 50,
+                visibility: 'visible',
+            },
+        ],
+    ]
+}
+
+function createModel(grid = createGrid()): DrawerInsert {
+    return {
+        config: {
+            totalWidth: 60,
+            totalDepth: 80,
+            wallThickness: 2,
+            cornerRadius: 4,
+            wallHeight: 24,
+            generateBottom: true,
+            maxBoxWidth: 40,
+            maxBoxDepth: 50,
+        },
+        grid,
+        selectedBoxIds: [],
+    }
+}
+
+function track<T extends THREE.Object3D>(object: T): T {
+    objectsToDispose.push(object)
+    return object
+}


### PR DESCRIPTION
## Summary
- Snapshot drawer state before export so STL and ZIP generation are decoupled from the live scene
- Build printable assemblies and per-box meshes directly from the domain model, excluding helpers and hidden objects
- Add tests covering deterministic serialization, snapshot immutability, and export geometry construction

## Testing
- Added unit tests for export model assembly and STL serialization behavior
- Added unit tests to verify snapshot isolation from mutable store state