### PR TITLE
Deduplicate STL exports by canonical shape footprint

### DIFF
--- a/lib/exportModel.ts
+++ b/lib/exportModel.ts
@@ -1,5 +1,6 @@
 import { generateCustomBox } from '@/lib/boxHelper'
 import { getGridBoxes } from '@/lib/gridVisibility'
+import { getOutline } from '@/lib/lineHelper'
 import { disposeObject } from '@/lib/threeDisposal'
 import type {
     DrawerInsert,
@@ -12,6 +13,12 @@ import * as THREE from 'three'
 export type ExportBoxMesh = {
     metadata: GeneratedBoxMetadata
     mesh: THREE.Group
+    shapeSignature: string
+}
+
+export type ExportBoxMeshGroup = {
+    representative: ExportBoxMesh
+    count: number
 }
 
 /**
@@ -58,11 +65,77 @@ export function buildExportBoxMeshes(model: DrawerInsert): ExportBoxMesh[] {
 
             assembly.remove(mesh)
             positionAtLocalOrigin(mesh, model.grid, metadata)
-            return { metadata, mesh }
+            return {
+                metadata,
+                mesh,
+                shapeSignature: createExportShapeSignature(model, metadata),
+            }
         })
 
     disposeObject(assembly)
     return result
+}
+
+/** Group rotationally equivalent meshes while preserving distinct footprints. */
+export function groupExportBoxMeshes(
+    entries: ExportBoxMesh[]
+): ExportBoxMeshGroup[] {
+    const groups = new Map<string, ExportBoxMeshGroup>()
+
+    entries.forEach((entry) => {
+        const group = groups.get(entry.shapeSignature)
+        if (group) group.count++
+        else
+            groups.set(entry.shapeSignature, {
+                representative: entry,
+                count: 1,
+            })
+    })
+
+    return [...groups.values()]
+}
+
+/**
+ * Canonicalize the printable footprint and mesh-affecting options under quarter
+ * turns. Removing collinear seams makes the signature independent of how an
+ * otherwise identical shape is partitioned in the source grid.
+ */
+export function createExportShapeSignature(
+    model: DrawerInsert,
+    metadata: GeneratedBoxMetadata
+): string {
+    const cumulativeWidths = cumulative(model.grid[0].map((cell) => cell.width))
+    const cumulativeDepths = cumulative(model.grid.map((row) => row[0].depth))
+    const rawOutline = metadata.isCombined
+        ? getOutline(model.grid, metadata.group)
+        : rectangleOutline(metadata, cumulativeWidths, cumulativeDepths)
+    const outline = removeCollinearPoints(rawOutline)
+    const footprint = Array.from({ length: 4 }, (_, turns) => {
+        const rotated = outline.map((point) =>
+            rotateQuarterTurn(point.x, point.y, turns)
+        )
+        const minimumX = Math.min(...rotated.map(([x]) => x))
+        const minimumZ = Math.min(...rotated.map(([, z]) => z))
+        const points = rotated.map(([x, z]) =>
+            [x - minimumX, z - minimumZ].map(quantize).join(',')
+        )
+
+        return points
+            .map((_, start) =>
+                [...points.slice(start), ...points.slice(0, start)].join(';')
+            )
+            .sort()[0]
+    }).sort()[0]
+    const options = [
+        model.config.wallThickness,
+        model.config.cornerRadius,
+        model.config.wallHeight,
+        model.config.generateBottom ? 1 : 0,
+    ]
+        .map(quantize)
+        .join('|')
+
+    return `${options}|${footprint}`
 }
 
 function exportOptions(config: ModelConfig) {
@@ -94,4 +167,59 @@ function positionAtLocalOrigin(
         .reduce((sum, row) => sum + row[0].depth, 0)
 
     mesh.position.set(-xOffset, 0, -zOffset)
+}
+
+function rectangleOutline(
+    metadata: GeneratedBoxMetadata,
+    cumulativeWidths: number[],
+    cumulativeDepths: number[]
+): THREE.Vector2[] {
+    const [{ x, z }] = metadata.cells
+    return [
+        new THREE.Vector2(cumulativeWidths[x], cumulativeDepths[z]),
+        new THREE.Vector2(cumulativeWidths[x + 1], cumulativeDepths[z]),
+        new THREE.Vector2(cumulativeWidths[x + 1], cumulativeDepths[z + 1]),
+        new THREE.Vector2(cumulativeWidths[x], cumulativeDepths[z + 1]),
+    ]
+}
+
+function removeCollinearPoints(points: THREE.Vector2[]): THREE.Vector2[] {
+    return points.filter((current, index) => {
+        const previous = points[(index + points.length - 1) % points.length]
+        const next = points[(index + 1) % points.length]
+        const first = current.clone().sub(previous)
+        const second = next.clone().sub(current)
+        return Math.abs(first.x * second.y - first.y * second.x) > 1e-8
+    })
+}
+
+function cumulative(values: number[]): number[] {
+    return values.reduce<number[]>(
+        (result, value) => {
+            result.push(result.at(-1)! + value)
+            return result
+        },
+        [0]
+    )
+}
+
+function rotateQuarterTurn(
+    x: number,
+    z: number,
+    turns: number
+): [number, number] {
+    switch (turns) {
+        case 1:
+            return [-z, x]
+        case 2:
+            return [-x, -z]
+        case 3:
+            return [z, -x]
+        default:
+            return [x, z]
+    }
+}
+
+function quantize(value: number): string {
+    return (Math.round(value * 1e5) / 1e5).toFixed(5)
 }

--- a/lib/exportUtils.ts
+++ b/lib/exportUtils.ts
@@ -1,7 +1,7 @@
 import {
     buildExportAssembly,
     buildExportBoxMeshes,
-    type ExportBoxMesh,
+    groupExportBoxMeshes,
 } from '@/lib/exportModel'
 import { useStore } from '@/lib/store'
 import { disposeObject } from '@/lib/threeDisposal'
@@ -28,8 +28,7 @@ export function handleStlExport(): void {
 }
 
 /**
- * Export unique boxes (deduped by W×D×H, swap-insensitive) as separate STLs
- * with a `_qtyN` suffix and pack into a ZIP.
+ * Export unique box shapes as separate STLs with a `_qtyN` suffix in a ZIP.
  */
 export async function handleExportMultipleSTLs(): Promise<void> {
     const model = createExportModelSnapshot(useStore.getState())
@@ -37,57 +36,28 @@ export async function handleExportMultipleSTLs(): Promise<void> {
 
     const exportMeshes = buildExportBoxMeshes(model)
 
-    // group boxes by dimensions (ignoring width↔depth swap)
-    type GroupInfo = {
-        representative: ExportBoxMesh
-        count: number
-        w: number
-        d: number
-        h: number
-        isCombined: boolean
-    }
-    const groups = new Map<string, GroupInfo>()
-
-    exportMeshes.forEach((entry) => {
-        const metadata = entry.metadata
-        const rawW = metadata.dimensions.width
-        const rawD = metadata.dimensions.depth
-        const h = metadata.dimensions.height
-        const isCombined = metadata.isCombined
-        const [w, d] = [rawW, rawD].sort((a, b) => a - b)
-        const prefix = isCombined ? 'combined_box' : 'box'
-        const key = `${prefix}_${w.toFixed(2)}_${d.toFixed(2)}_${h.toFixed(2)}`
-
-        if (groups.has(key)) {
-            groups.get(key)!.count++
-        } else {
-            groups.set(key, {
-                representative: entry,
-                count: 1,
-                w,
-                d,
-                h,
-                isCombined,
-            })
-        }
-    })
+    const groups = groupExportBoxMeshes(exportMeshes)
 
     try {
         const JSZip = (await import('jszip')).default
         const zip = new JSZip()
         let uniqIndex = 1
 
-        for (const [, info] of groups) {
-            const { representative, count, w, d, h, isCombined } = info
+        for (const { representative, count } of groups) {
+            const { dimensions, isCombined } = representative.metadata
+            const [w, d] = [dimensions.width, dimensions.depth].sort(
+                (a, b) => a - b
+            )
             const qtySuffix = count > 1 ? `_qty${count}` : ''
-            const filename = `${isCombined ? 'combined_box' : 'box'}_${uniqIndex}_${w.toFixed(0)}x${d.toFixed(0)}x${h.toFixed(0)}mm${qtySuffix}.stl`
+            const filename = `${isCombined ? 'combined_box' : 'box'}_${uniqIndex}_${w.toFixed(0)}x${d.toFixed(0)}x${dimensions.height.toFixed(0)}mm${qtySuffix}.stl`
             zip.file(filename, serializeStl(representative.mesh))
             uniqIndex++
         }
 
         const readme = `# Box Grid Export
 
-This ZIP contains ${groups.size} unique box designs (_qtyN suffix shows multiples_).
+This ZIP contains ${groups.length} unique box designs (_qtyN suffix shows multiples_).
+Designs are deduplicated by their actual footprint, including non-rectangular shapes.
 
 ## File Naming Convention
 - Regular boxes: box_[i]_[W]x[D]x[H]mm[_qtyN].stl  

--- a/tests/exportModel.test.ts
+++ b/tests/exportModel.test.ts
@@ -1,4 +1,8 @@
-import { buildExportAssembly, buildExportBoxMeshes } from '@/lib/exportModel'
+import {
+    buildExportAssembly,
+    buildExportBoxMeshes,
+    groupExportBoxMeshes,
+} from '@/lib/exportModel'
 import { createExportModelSnapshot, serializeStl } from '@/lib/exportUtils'
 import { useStore } from '@/lib/store'
 import { disposeObject } from '@/lib/threeDisposal'
@@ -29,8 +33,7 @@ describe('export model generation', () => {
     })
 
     it('positions separate meshes at a stable local origin in model order', () => {
-        const entries = buildExportBoxMeshes(createModel())
-        entries.forEach(({ mesh }) => track(mesh))
+        const entries = trackEntries(buildExportBoxMeshes(createModel()))
 
         expect(entries.map(({ metadata }) => metadata.id)).toEqual([
             'group:7',
@@ -42,6 +45,129 @@ describe('export model generation', () => {
             expect(bounds.min.y).toBeCloseTo(0)
             expect(bounds.min.z).toBeCloseTo(0)
         })
+    })
+
+    it('keeps different footprints with identical bounds as separate designs', () => {
+        const entries = trackEntries(
+            buildExportBoxMeshes(
+                createModel([
+                    [
+                        { group: 1, width: 10, depth: 10 },
+                        { group: 1, width: 10, depth: 10 },
+                        { group: 1, width: 10, depth: 10 },
+                        {
+                            group: 0,
+                            width: 10,
+                            depth: 10,
+                            visibility: 'hidden',
+                        },
+                        { group: 2, width: 10, depth: 10 },
+                        { group: 2, width: 10, depth: 10 },
+                        { group: 2, width: 10, depth: 10 },
+                    ],
+                    [
+                        { group: 1, width: 10, depth: 10 },
+                        {
+                            group: 0,
+                            width: 10,
+                            depth: 10,
+                            visibility: 'hidden',
+                        },
+                        {
+                            group: 0,
+                            width: 10,
+                            depth: 10,
+                            visibility: 'hidden',
+                        },
+                        {
+                            group: 0,
+                            width: 10,
+                            depth: 10,
+                            visibility: 'hidden',
+                        },
+                        {
+                            group: 0,
+                            width: 10,
+                            depth: 10,
+                            visibility: 'hidden',
+                        },
+                        { group: 2, width: 10, depth: 10 },
+                        {
+                            group: 0,
+                            width: 10,
+                            depth: 10,
+                            visibility: 'hidden',
+                        },
+                    ],
+                ])
+            )
+        )
+
+        expect(entries.map(({ metadata }) => metadata.dimensions)).toEqual([
+            { width: 30, depth: 20, height: 24 },
+            { width: 30, depth: 20, height: 24 },
+        ])
+        expect(groupExportBoxMeshes(entries)).toHaveLength(2)
+    })
+
+    it('deduplicates identical, rotated, and partition-independent shapes', () => {
+        const identical = trackEntries(
+            buildExportBoxMeshes(
+                createModel([
+                    [
+                        { group: 0, width: 20, depth: 20 },
+                        { group: 0, width: 20, depth: 20 },
+                    ],
+                ])
+            )
+        )
+        const identicalGroups = groupExportBoxMeshes(identical)
+
+        expect(identicalGroups).toHaveLength(1)
+        expect(identicalGroups[0].count).toBe(2)
+
+        const rotated = trackEntries(
+            buildExportBoxMeshes(
+                createModel([
+                    [
+                        {
+                            group: 0,
+                            width: 10,
+                            depth: 10,
+                            visibility: 'hidden',
+                        },
+                        { group: 0, width: 20, depth: 10 },
+                    ],
+                    [
+                        { group: 0, width: 10, depth: 20 },
+                        {
+                            group: 0,
+                            width: 20,
+                            depth: 20,
+                            visibility: 'hidden',
+                        },
+                    ],
+                ])
+            )
+        )
+
+        expect(groupExportBoxMeshes(rotated)).toHaveLength(1)
+
+        const differentlyPartitioned = trackEntries(
+            buildExportBoxMeshes(
+                createModel([
+                    [
+                        { group: 3, width: 10, depth: 20 },
+                        { group: 3, width: 20, depth: 20 },
+                        { group: 0, width: 30, depth: 20 },
+                    ],
+                ])
+            )
+        )
+        const partitionGroups = groupExportBoxMeshes(differentlyPartitioned)
+
+        expect(partitionGroups).toHaveLength(1)
+        expect(partitionGroups[0].count).toBe(2)
     })
 
     it('serializes deterministically despite display-state changes', () => {
@@ -167,4 +293,9 @@ function createModel(grid = createGrid()): DrawerInsert {
 function track<T extends THREE.Object3D>(object: T): T {
     objectsToDispose.push(object)
     return object
+}
+
+function trackEntries<T extends { mesh: THREE.Object3D }[]>(entries: T): T {
+    entries.forEach(({ mesh }) => track(mesh))
+    return entries
 }


### PR DESCRIPTION
## Summary
- Group export meshes by a canonical footprint signature instead of only by swapped dimensions.
- Preserve distinct non-rectangular layouts while deduplicating identical and rotated shapes.
- Update the ZIP export naming and README text to reflect footprint-based grouping.
- Add unit coverage for identical, rotated, and partition-independent shapes.

## Testing
- Added unit tests covering export mesh grouping and signature behavior.
- Not run (not requested).