### PR TITLE
Set up development environment (Node 24, deps, dev server) + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a single, purely client-side Next.js app (`drawer-inserts-generator`, "Box Grid Generator"). There is no backend, database, or external service — the entire product runs in the browser and is served by one Next.js dev server. All geometry generation and model export (STL/3MF via `three`, `three-csg-ts`, `jszip`) happens client-side.
+
+### Node version (important gotcha)
+- The project requires Node `24.x` (see `.node-version` / `package.json` `engines`). Node 24.18.0 is installed via `nvm` and is the default.
+- The base VM ships an `/exec-daemon/node` (v22) that takes PATH precedence in non-login shells. A one-off line was added to `~/.bashrc` prepending the nvm Node 24 bin, so **login shells** (e.g. `bash -l`, tmux sessions started with a login shell) correctly resolve `node` -> v24.18.0. Verify with `node --version` before running commands; if it shows v22, run `nvm use 24.18.0` or start a login shell.
+
+### Commands (see `package.json` scripts; mirrors `.github/workflows/ci.yml`)
+- Dev server: `npm run dev` (serves http://localhost:3000). Run it from a login shell so Node 24 is used.
+- Checks: `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run test` (Vitest, `tests/`).
+- Production build: `npm run build` then `npm run start`.
+
+### Notes
+- `npm ci` prints an `allow-scripts` warning that `sharp` and `unrs-resolver` install scripts were not run. This does not affect the dev server or the tests/lint/typecheck flow.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the **Box Grid Generator** (`drawer-inserts-generator`), a purely client-side Next.js 16 / React 19 app for generating 3D-printable box grids. There is no backend, database, or external service — the whole product runs in one Next.js dev server.

Adds `AGENTS.md` documenting a non-obvious Node-version gotcha and standard commands for future cloud agents.

## Environment setup performed
- Installed Node `24.18.0` via `nvm` (project requires `24.x`; base VM's `/exec-daemon/node` is v22 and wins in non-login shells — added a one-off `~/.bashrc` prepend so login shells resolve Node 24).
- Upgraded npm to `11.18.0` to satisfy `engines`.
- Installed dependencies with `npm ci`.
- Update script registered: `npm ci` (via Node 24's npm).

## Verification
All checks from `.github/workflows/ci.yml` pass, plus the dev server runs and the core export flow works end-to-end:

- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm run format:check` — pass
- `npm run test` — 72 tests pass
- `npm run dev` — serves http://localhost:3000 (HTTP 200)
- Hello-world: changed Wall Height slider, 3D preview updated live, exported an STL model successfully

[box_grid_generator_export_demo.mp4](https://cursor.com/agents/bc-bfde86f8-aeef-4842-b0a8-053860624616/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbox_grid_generator_export_demo.mp4)

[Initial loaded state](https://cursor.com/agents/bc-bfde86f8-aeef-4842-b0a8-053860624616/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbox_grid_initial.webp)
[Export success](https://cursor.com/agents/bc-bfde86f8-aeef-4842-b0a8-053860624616/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbox_grid_export_done.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfde86f8-aeef-4842-b0a8-053860624616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfde86f8-aeef-4842-b0a8-053860624616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

